### PR TITLE
LD-4321:-add-initial-terms-and-conditions-page-for-LLTry

### DIFF
--- a/termsandconditions/lltry-terms-and-conditions.html
+++ b/termsandconditions/lltry-terms-and-conditions.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-173128924-1"></script>
+    <script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-173128924-1');
+</script>
+
+    <meta charset="UTF-8">
+    <title>Lifelight License Terms</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,700&display=swap" rel="stylesheet">
+    <link href="ll-t&cs.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+<main class = "centred">
+<section> <!--cover & title-->
+    <h1>Lifelight LLTry Demo Application License Terms</h1>
+</section>
+<h3>PLEASE READ THESE LICENCE TERMS CAREFULLY</h3>
+<p>LLTry is a demonstration version of the Lifelight technology, made available by Xim Limited to  allow users to explore the capabilities of our non-contact vital signs technology. It is <b>not a medical device</b> and must <b>not</b> be used 
+    for diagnosis, monitoring, or treatment. LLTry is provided for illustrative and evaluation purposes only and does <b>not</b> provide medical-grade results.</p>
+<p>You are responsible for ensuring that all persons who access this application from your
+    device are aware of these terms and comply with them.</p>
+<p>By ticking the box, you agree to these terms which will bind you.</p>
+<p>If you do not agree to these terms do not tick the box.</p>
+<h3>WHO WE ARE AND WHAT THESE TERMS DO</h3>
+<p>Xim Limited (company number 03699022)<b>(we</b> / <b>us</b> / <b>our</b> / <b>Xim)</b>
+    licenses you, whether acting as a healthcare professional to provide
+    health and patient care services (Healthcare Professional) or a patient for
+    your own purposes <b>(Patient)</b>, to use:</p>
+<ul>
+    <li>the LLTry mobile application software, the data supplied 
+        with the software and any updates or supplements to it as 
+        supplied from time to time <b>(Lifelight Application)</b>;
+    </li>
+    <li>the related electronic documentation <b>(Documentation)</b>; and
+    </li>
+    <li>the services and content you access via the LLTry Application
+        (together <b>LLTry</b>), as permitted in these terms.  
+    </li>
+</ul>
+    <p>Lifelight® is a registered trademark of Xim Limited. Any rights not
+        expressly granted by us under these terms are reserved.</p>
+    <p>Our address is University of Southampton Science Park, Venture
+        Road, Chilworth, Southampton, Hampshire, England, SO16 7NP. Our VAT
+        number is 726893394.</p>
+    <p>LLTry is a <b>demonstration tool</b> intended to showcase the potential of the Lifelight technology.
+    <b>It is not a medical device</b> and must <b>not be used for diagnosis, monitoring, or treatment.</b>
+    </p>
+<h3>YOUR PRIVACY</h3>
+<p>We only use your personal data to:</p>
+<ul>
+    <li>provide access to LLTry;</li>
+    <li>monitor demo performance and usage analytics;</li>
+</ul>
+    <p>For more information, please see our <a href=" https://lifelight.ai/privacy-notice/">Privacy Notice</a>,.<br>
+        LLTry is not intended to process or store any personal health information for clinical use.</p>
+<h3>ACCESS TO CAMERA</h3>
+<p>LLTry will need access to the inbuilt camera on the Device (as
+    defined below). Without access to the camera Lifelight will not be able to
+    provide Vital Sign predictions.</p>
+<p>You will be asked to enable this functionality when you first access
+    the LLTry Application. You can change camera permissions at any time in your device settings.</p>
+<h3>OPERATING SYSTEM REQUIREMENTS</h3>
+<p>Lifelight is designed to work on any smartphone or tablet device
+    provided that it has a built-in camera with a minimum specification of 5
+    megapixels, capable of HD quality video of 1280p x 720p resolution at 30
+    frames per second <b>(Device)</b>.</p>
+<h3>SUPPORT FOR LLTry</h3>
+    <p>Support is available via in-app help or by contacting: <a href="mailto:support@lifelight.ai">support@lifelight.ai</a></p>
+<p><b>How we will communicate with you.</b> If we respond to you, we will do so by email, using the email
+    address you have provided to us.</p>
+<h3>HOW YOU MAY USE LLTry</h3>
+<p>In return for agreeing to these terms:</p>
+<ul>
+    <li>You may install LLTry on a compatible device for personal demonstration 
+        purposes only;
+    </li>
+    <li>You may use the documentation provided to support your use of LLTry;
+    </li>
+    <li>You may receive and use free updates or patches we provide.
+    </li>
+</ul>
+<p>You must be 18 or over to use LLTry.</p>
+<p>You may not transfer LLTry to another person without our written permission.</p>
+<h3>CHANGES TO THESE TERMS</h3>
+<p>We may update these terms to reflect changes in law, improvements to LLTry, or feedback.
+    We'll notify you of any changes. If you do not accept the updated terms, 
+    you must stop using LLTry.</p>
+<h3>OTHER TERMS MAY ALSO APPLY</h3>
+<p>The ways in which you can use Lifelight may also be controlled
+    by:</p>
+<ul>
+    <li>the rules and policies of the app store from which you have
+        downloaded LLTry
+    </li>
+</ul>
+<h3>UPDATES TO LLTry</h3>
+<br>
+<h3>OTHER TERMS THAT MAY APPLY</h3>
+<p>Your use of LLTry may also be governed by:</p>
+<ul>
+    <li>The rules and policies of the app store from which you 
+        downloaded LLTry.</li>
+</ul>
+<h3>UPDATES TO LLTRY</h3>
+<p>We may automatically update LLTry to improve performance, security, or functionality.
+    If you choose not to install updates, LLTry may no longer function.</p>
+<h3>IF SOMEONE ELSE OWNS THE DEVICE YOU ARE USING</h3>
+<p>If you install LLTry on a device you do not own, 
+    you must have permission to do so. You are
+    responsible for complying with these terms.</p>
+<h3>WE ARE NOT RESPONSIBLE FOR OTHER WEBSITES YOU LINK
+    TO</h3>
+<p>LLTry may contain links to other independent websites which are
+    not provided by us. Those independent sites are not under our control,
+    and we are not responsible for and have not checked and approved their
+    content or their privacy policies (if any).</p>
+<p>You will need to make your own independent judgment about
+    whether to use any independent sites, including whether to buy any
+    products or services offered by them or follow advice or recommendations
+    given by them.</p>
+<h3>LICENCE RESTRICTIONS</h3>
+<p>You agree that you will:</p>
+<ul>
+    <li>not rent, lease, sub-license, loan, provide, or otherwise make
+        available, LLTry in any form, in whole or in part to any person without
+        prior written consent from us;
+    </li>
+    <li>not copy LLTry (or any part of it), except as part of the normal
+        use of LLTry or where it is necessary for the purpose of back-up or
+        operational security;
+    </li>
+    <li>not translate, merge, adapt, vary, alter or modify, the whole or
+        any part of LLTry nor permit LLTry or any part of it to be combined
+        with, or become incorporated in, any other programs, except as necessary
+        to use Lifelight on devices as permitted in these terms;
+    </li>
+    <li>not disassemble, de-compile, reverse engineer or create
+        derivative works based on the whole or any part of LLTry nor attempt to
+        do any such things, except to the extent that (by virtue of sections 50B
+        and 296A of the Copyright, Designs and Patents Act 1988) such actions
+        cannot be prohibited because they are necessary to decompile the
+        Application to obtain the information necessary to create an
+        independent program that can be operated with the Application
+        or with another program (Permitted Objective), and provided that the
+        information obtained by you during such activities:
+        <ul>
+            <li>is not disclosed or communicated without our prior written
+                consent to any third party to whom it is not necessary to disclose or
+                communicate it in order to achieve the Permitted Objective; and
+            </li>
+            <li>is not used to create any software that is substantially
+                similar in its expression to the Application;
+            </li>
+            <li>is kept secure; and</li>
+            <li>is used only for the Permitted Objective;</li>
+        </ul>
+    </li>
+    <li>comply with all applicable technology control or export laws and
+        regulations that apply to the technology used or supported by
+        LLTry.
+    </li>
+</ul>
+<h3>ACCEPTABLE USE RESTRICTIONS</h3>
+<p>You must:</p>
+<ul>
+    <li>not use LLTry in any unlawful manner, for any unlawful
+        purpose, or in any manner inconsistent with these terms, or act
+        fraudulently or maliciously, for example by hacking into or inserting
+        malicious code, such as viruses, or harmful data, into LLTry or any
+        operating system;
+    </li>
+    <li>not infringe our intellectual property rights or those of any third
+        party in relation to your use of LLTry;
+    </li>
+    <li>not transmit any material that is defamatory, offensive, or
+        otherwise objectionable in relation to your use of LLTry;
+    </li>
+    <li>not use LLTry in a way that could damage, disable,
+        overburden, impair, or compromise our systems or security or interfere
+        with other users; and
+    </li>
+    <li>not collect or harvest any information or data from LLTry or
+        our systems or attempt to decipher any transmissions to or from the
+        servers running LLTry.
+    </li>
+</ul>
+<h3>INTELLECTUAL PROPERTY RIGHTS</h3>
+<p>You acknowledge that all intellectual property rights in LLTry
+    throughout the world belong to us (or our licensors), that rights in Lifelight
+    are licensed (not sold) to you, and that you have no intellectual property
+    rights in, or to, LLTry other than the right to use LLTry in accordance
+    with these terms.</p>
+<h3>OUR RESPONSIBILITY FOR LOSS OR DAMAGE SUFFERED BY YOU –
+    THIS CLAUSE ONLY APPLIES TO PATIENTS.</h3>
+<p>LLTry is provided "as is" for demonstration purposes only. We do not
+    warrant that the application is accurate, reliable, or fit for any medical 
+    or diagnostic purpose.</p>
+<p><b>We are responsible to you for foreseeable loss and damage caused
+    by us.</b> If we fail to comply with these terms, we are responsible for loss or
+    damage you suffer that is a foreseeable result of our breaking these terms
+    or our failing to use reasonable care and skill, but we are not responsible
+    for any loss or damage that is not foreseeable. Loss or damage is
+    foreseeable if either it is obvious that it will happen or if, at the time this
+    licence was made, both we and you knew it might happen.</p>
+<p><b>We do not exclude or limit in any way our liability to you where it
+    would be unlawful to do so.</b> This includes liability for death or personal
+    injury caused by our negligence or the negligence of our employees,
+    agents, or subcontractors or for fraud or fraudulent
+    misrepresentation.</p>
+    <p><b>When we are liable for damage to your property.</b> If defective digital
+        content that we have supplied damages a device or digital content
+        belonging to you, we will either repair the damage or pay you
+        compensation. However, we will not be liable for damage that you could
+        have avoided by following our advice to apply an update offered to you
+        free of charge or for damage that was caused by you failing to correctly
+        follow installation instructions or to have in place the minimum system
+        requirements advised by us.</p>
+<h3>IN THE EVENT OF ANY MEDICAL EMERGENCIES YOU SHOULD ALWAYS CALL
+    YOUR HEALTHCARE PROVIDER DIRECTLY OR USE YOUR NATIONAL
+    HEALTHCARE SYSTEM’S HELPLINES.</h3>
+   <br>
+<h3>WE MAY END YOUR RIGHTS TO USE LIFELIGHT IF YOU BREAK
+    THESE TERMS</h3>
+<p>If we consider that a breach of these terms has occurred, we may
+    take such action as we deem appropriate.</p>
+<p>If you have broken these terms in a serious way, we may take all or any of the
+    following actions:</p>
+<ul>
+    <li>immediate, temporary or permanent withdrawal of your right to
+        use LLTry;
+    </li>
+    <li>immediate, temporary or permanent removal of any data
+        uploaded by you to LLTry;
+    </li>
+    <li>issue of a warning to you;
+    </li>
+    <li>legal action against you;
+    </li>
+    <li>disclosure of such information to law enforcement authorities as
+        we reasonably feel is necessary or as required by law.
+    </li>
+</ul>
+<p>The actions we may take are not limited to those described above,
+    and we may take any other action we reasonably deem appropriate.</p>
+<p>If we end your rights to use LLTry:</p>
+<ul>
+    <li>you must stop all activities authorised by these terms, including
+        your use of LLTry.
+    </li>
+    <li>you must delete or remove the Application from
+        the device in your possession and immediately destroy all and any copies
+        of the Application which you have and confirm to us that you
+        have done so;
+    </li>
+</ul>
+<h3>TRANSFERRING THIS LICENCE TO SOMEONE ELSE</h3>
+<p>We may transfer, assign, charge, sub-contract, or deal in any other
+    manner with all or any of our rights and obligations under these
+    terms.</p>
+<p>You, however, may only transfer your rights or your obligations
+    under these terms to another person if we agree in writing.</p>
+<h3>RIGHTS FOR THIRD PARTIES</h3>
+<p>Except the rights the organisation you represent has, these terms
+    do not give rise to any rights under the Contracts (Rights of Third Parties)
+    Act 1999 to enforce any of its terms.</p>
+<h3>IF A COURT FINDS PART OF THIS CONTRACT ILLEGAL, THE REST
+    WILL CONTINUE IN FORCE</h3>
+<p>Each of the paragraphs of these terms operates separately. If any
+    court or relevant authority decides that any of them are unlawful, the
+    remaining paragraphs will remain in full force and effect.</p>
+<h3>EVEN IF WE DELAY ENFORCING THESE TERMS, WE CAN STILL
+    ENFORCE THEM LATER</h3>
+<p>Even if we delay in enforcing of these terms, we can still enforce
+    them later. If we do not insist immediately that you do anything you are
+    required to do under this licence, or if we delay in taking steps against you
+    in respect of your breaking these terms that will not mean that you do not
+    have to do those things and it will not prevent us from taking steps
+    against you at a later date.</p>
+<h3>WHICH LAWS APPLY TO THESE TERMS AND JURISDICTION</h3>
+<p>These terms, their subject matter and formation (and any non- contractual disputes or claims) are
+    governed by English law and subject to the exclusive jurisdiction of the courts of England and Wales.
+    If you are not based in England and Wales, you can bring legal proceedings in respect of Lifelight in
+    the country that you are based in.</p>
+<p><strong>By ticking the box, you agree to these terms which will bind you.</strong></p>
+<p><strong>If you do not agree to these terms do not tick the box.</strong></p>
+</main>
+</body>
+</html>


### PR DESCRIPTION
Created an HTML page for the LLTry demo application's license terms, following the layout and structure of the existing terms and conditions page: https://xim-lifelight.github.io/termsandconditions/lifelight-terms-and-conditions.html
Based on the content https://lifelight.atlassian.net/jira/software/c/projects/LD/boards/31?assignee=712020%3A61d98e18-cc10-42c2-a647-9b5e87a614d2&selectedIssue=LD-4321