### PR TITLE
LD-4385: Added French HTML pages

### DIFF
--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-fr.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-fr.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<!-- saved from url=(0071)https://xim-lifelight.github.io/ifu/ll-ifu/ll-singleproduct-ifu-c1.html -->
+<html>
+<head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script type="text/javascript" async="" src="./Lifelight – Instructions For Use (single product)_files/analytics.js"></script><script type="text/javascript" async="" src="./Lifelight – Instructions For Use (single product)_files/js"></script><script async="" src="./Lifelight – Instructions For Use (single product)_files/js(1)"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-173128924-1');
+    </script>
+
+    <title>Lifelight – Instructions d’utilisation (produit unique)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="llifu-styles.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+<main class="centred">
+    <section id="logo"> <!--cover & title-->
+
+        <div class="container">
+            <img src="img/lifelight_logo_updated.SVG" alt="logo" width="180px" height="150px">
+        </div>
+        <h1>Lifelight® </h1>
+        <h2>Instructions d’utilisation</h2>
+        <img src="img/operator and subject.svg" alt="sujet et opérateur avec lifelight" width="400px" class="img-reduced"></section>
+    <section id="info"><!--top plate info COPY FROM HERE-->
+        <div class="column2">
+            <p><strong>Date d’émission : mai 2025</strong> <br>
+                <strong>Réf. des instructions d’utilisation :</strong> REC-QMS-005<br>
+                <strong>Révision :</strong><br>
+                <strong>Si révision, date de la révision :</strong>  <br>
+                <strong>Numéro de contrôle :</strong> CC-2024-002<br>
+                <strong>Identifiant unique du dispositif :</strong> 05060776720019<br>
+                <strong>Nom du dispositif :</strong> Lifelight<br>
+                <strong>Marque commerciale :</strong> Lifelight</p>
+        </div>
+        <div class="columnSQ">
+            <p><img src="img/factory.svg" alt="usine" width="40px"> <strong>Fabricant</strong></p>
+            <p>XIM Ltd.<br>
+                University of Southampton Science Park<br>
+                2 Venture Road<br>
+                Southampton<br>
+                Hampshire<br>
+                Royaume-Uni<br>
+                SO16 7NP</p>
+        </div>
+        <div class="column-holder2">
+            <div class="columnSQ">
+                <p><img src="img/ll-qr.svg" alt="ll-qr" width="150px"></p>
+            </div>
+            <div class="columnSQ">
+                <p class="small">(01)05060776720019 </p>
+                <p class="small">(11)</p>
+                <p class="small">(21)LLF-002</p>
+                <p class="small">(8012)</p>
+            </div>
+        </div>
+        <h3>Symboles sur le dispositif et documentation</h3>
+        <p> Les symboles et étiquettes qui apparaissent dans le présent manuel et dans l’application ont les significations suivantes :</p>
+        <table class="blueTable">
+            <colgroup><col width="120px">
+                <!--<col width="70%">-->
+            </colgroup><thead>
+        <tr>
+            <th style="text-align:center">Symbole</th>
+            <th>Description</th>
+        </tr>
+        </thead>
+            <tbody>
+            <tr>
+                <td style="text-align:center"><img src="img/serial.svg" alt="usine" height="40px"></td>
+                <td><p>Numéro de série.<br>
+                    Le numéro de série de cet appareil est : LLF-002.</p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/catalog.svg" alt="usine" height="40px"></td>
+                <td><p>Numéro de catalogue.<br>
+                    Le numéro de catalogue du présent dispositif est : LLF-002.</p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/consult.svg" alt="usine" height="40px"></td>
+                <td><p>Consulter les instructions d’utilisation.</p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/medical.svg" alt="usine" height="40px"></td>
+                <td><p>Indique que l’article est un dispositif médical. </p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/date.svg" alt="usine" width="40px"></td>
+                <td><p>Date de fabrication.</p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/factory.svg" alt="usine" width="40px"></td>
+                <td><p>Nom et adresse du fabricant</p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/caution.svg" alt="attention" width="40px"></td>
+                <td><p>Attention.</p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/ce.svg" alt="ce" width="40px"> <br>
+                    0123</td>
+                <td><p>Conforme au règlement (UE) 2017/745 du Parlement européen et du Conseil du 5 avril 2017 relatif aux dispositifs médicaux. </p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/ecrep.svg" alt="ecrep" width="80px"> </td>
+                <td><p>Nom et adresse du représentant autorisé au sein de l’Union européenne (UE) </p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/chrep.svg" alt="chrep" width="80px"> </td>
+                <td><p>Nom et adresse du représentant autorisé en Suisse </p></td>
+            </tr>
+            <tr>
+                <td style="text-align:center"><img src="img/importer.png" alt="importateur" width="40px"> </td>
+                <td><p>Nom et adresse de l’importateur pour le pays/la région/la juridiction précisé(e) </p></td>
+            </tr>
+            </tbody>
+        </table>
+    </section>
+    <div class="break"></div>
+    <!--PRINT BREAK-->
+    <section id="intended"> <!--Intended use-->
+        <h2>Utilisation prévue/instructions d’utilisation de Lifelight</h2>
+        <div class="column2">
+            <p>Le logiciel du dispositif médical sans contact Lifelight est destiné à la mesure non invasive de la pression artérielle (mmHg) et de la fréquence du pouls (bpm) chez les patients adultes âgés de 18 ans et plus, indépendamment de leur origine ethnique ou de leur sexe. Le logiciel n’est pas destiné aux femmes enceintes, à un usage pédiatrique ou aux personnes souffrant de fibrillation auriculaire ou de conditions de faible perfusion telles que l’anémie, la jaunisse, les taches de naissance, la rosacée, le psoriasis, l’acné aiguë ou la protoporphyrie érythropoïétique. Lifelight mesure les paramètres physiologiques vitaux par une méthode appelée photopléthysmographie à distance (rPPG), qui est un moyen non invasif de détecter le pouls du volume sanguin cardiovasculaire (BVP) par de petites variations de la lumière réfléchie par la surface de la peau. Lifelight fonctionne en utilisant la caméra d’un appareil mobile pour détecter les changements de couleur infimes de la peau du visage d’un patient provoqués par les battements de son cœur.</p>
+            <p><strong>Population de Patients visée :</strong><br>
+                Patients adultes âgés de 18 ans et plus, indépendamment de leur origine ethnique ou de leur sexe. Le présent logiciel de dispositif médical n’est pas destiné aux femmes enceintes, à un usage pédiatrique ou aux personnes souffrant de fibrillation auriculaire ou de conditions de faible perfusion telles que l’anémie, la jaunisse, les taches de naissance, la rosacée, le psoriasis, l’acné aiguë ou la protoporphyrie érythropoïétique.</p>
+            <p><strong>Environnements d’utilisation et utilisateurs visés :</strong><br>
+                Les contextes d’utilisation les plus probables sont les hôpitaux, les cliniques, les résidences médicalisées, tout autre structure de soin de santé et le domicile du patient.</p>
+            <p>Le logiciel Lifelight doit être utilisé par des professionnels de la santé ou par un patient qui a reçu les instructions d’un professionnel de la santé.</p>
+            <p>Lifelight est indiqué pour une utilisation sur des patients au repos, immobiles, dans un environnement bien éclairé.</p>
+            <h3><strong>Contre-indications, effets indésirables, informations utiles, remarques importantes concernant l’utilisation du logiciel Lifelight, mises en garde, avertissements et précautions :</strong></h3>
+            <p><strong>Contre-indications :</strong><br>
+                Lifelight n’a pas été validé pour une utilisation chez les femmes enceintes ou les personnes souffrant de fibrillation auriculaire. Nous conseillons donc de ne pas utiliser Lifelight sur ces types de sujets.</p>
+            <p>Lifelight n’est pas recommandé pour les personnes souffrant de conditions de faible perfusion telles que l’anémie, la jaunisse, les taches de naissance, la rosacée, le psoriasis, l’acné aiguë ou la protoporphyrie érythropoïétique.</p>
+            <p><strong>Effets indésirables :</strong><br>
+                Aucun effet ou réaction indésirable n’est connu, attendu ou prévisible dans le cadre de l’utilisation de Lifelight, qui est un logiciel de dispositif médical.</p>
+            <p><strong>Informations utiles :</strong><br>
+                Sachez que les paramètres vitaux peuvent fluctuer en fonction de légères modifications dans le corps et de l’heure de la journée. Une valeur constante au fil du temps est très inhabituelle. En cas de mesure régulière des paramètres vitaux, par exemple, de la pression artérielle sur plusieurs jours, l’idéal est de prendre les mesures à des horaires et dans des conditions identiques.</p>
+            <p>Si une mesure donne des résultats qui vous paraissent anormaux, mais que l’utilisateur se sent bien, ne paniquez pas : cela peut arriver. Il est important de se détendre pendant 5 minutes avant de mesurer à nouveau les paramètres vitaux. Une pression artérielle basse (hypotension), une pression artérielle élevée (hypertension), les raisons d’une fréquence cardiaque constamment rapide (tachycardie) ou constamment lente (bradycardie) ne peuvent être diagnostiquées que par un professionnel de la santé qualifié. Il est conseillé à la personne de contacter son médecin traitant ou son pharmacien si elle a des inquiétudes concernant les résultats.</p>
+            <p>Pour obtenir les valeurs les plus précises possibles, vous devez attendre au moins une heure après avoir mangé, fumé, consommé de la caféine, de l’alcool ou fait de l’exercice physique. Ces facteurs peuvent en effet affecter vos résultats. Restez détendu(e) et immobile pendant la mesure.</p>
+            <p><strong>Remarques importantes concernant l’utilisation :</strong><br>
+                Lifelight est uniquement destiné à l’usage décrit dans les présentes instructions d’utilisation. Le fabricant n’est pas responsable des dommages résultant d’une utilisation inappropriée ou négligente.</p>
+            <p>Dans les cas où une lecture de pouls forte n’est pas détectée par le logiciel, aucune mesure des paramètres vitaux ne sera renvoyée.</p>
+            <p><strong>Mises en garde :</strong><br>
+                Le présent logiciel est destiné à la mesure non invasive de la pression artérielle (mmHg) et de la fréquence du pouls (bpm) chez les patients adultes âgés de 18 ans et plus, indépendamment de leur origine ethnique ou de leur sexe. Il n’est pas destiné au traitement d’une affection médicale spécifique, mais à faciliter le diagnostic ou le traitement de ces affections médicales lorsque la mesure des paramètres vitaux est nécessaire.</p>
+            <p><img src="img/caution.svg" alt="mise en garde" width="30px" class="inline-shift"><strong>Avertissements :</strong><br>
+                Le présent logiciel ne dispose pas d’alarme en cas de dépassement des limites. Ne pas utiliser dans des situations où des alarmes sont nécessaires.</p>
+            <p><strong>Précautions :</strong><br>
+                Lifelight n’a pas été testé sur des personnes présentant les conditions suivantes, qui peuvent interférer avec les mesures. Nous recommandons donc d’utiliser un autre outil de mesure dans les cas suivants :</p>
+            <ul>
+                <li>Sujets présentant des arythmies cardiaques persistantes.</li>
+                <li>Sujets présentant un taux de mélanine élevé.</li>
+                <li>Sujets présentant des tatouages faciaux.</li>
+                <li>Sujets ayant subi une chirurgie plastique faciale.</li>
+                <li>Sujets ayant reçu des injections de botox.</li>
+                <li>Sujets présentant des cicatrices faciales ou des lambeaux cutanés.</li>
+                <li>Sujets présentant une hypothermie.</li>
+                <li>Sujets présentant une hyperthermie.</li>
+                <li>Sujets souffrant de migraine. </li>
+            </ul>
+        </div>
+        <h2>Remarques importantes sur la mesure par rapport à la surveillance :</h2>
+        <p>Lifelight n’est <strong>pas</strong> destiné à une surveillance continue de la pression artérielle ou du pouls. Il n’est <strong>pas</strong> non plus destiné à des contexte d’utilisation où une surveillance continue de
+            la pression artérielle ou du pouls est nécessaire. Lifelight est destiné à la mesure ponctuelle de la pression artérielle et du pouls.</p>
+    </section>
+    <!--TO HERE-->
+
+    <div class="break"></div>
+    <!--PRINT BREAK-->
+
+    <section id="warnings"> <!--warnings-->
+
+
+        <div class="">
+            <h2>Terminologie</h2>
+            <ul>
+                <li><strong>Qualité du signal de mesure ou MSQ</strong> : qualité des données mesurées par la caméra de l’appareil. Le terme ne concerne pas la connexion Wi-Fi ou de données.</li>
+                <li><strong>Opérateur</strong> : personne qui utilise Lifelight pour effectuer des mesures sur une autre personne. Par exemple, un médecin qui mesure les paramètres vitaux d’un patient.</li>
+                <li><strong>Sujet :</strong> personne sur laquelle les mesures sont effectuées. Elle peut les effectuer elle-même en utilisant l’application ou une autre personne, appelée opérateur dans le présent document, peut le faire.</li>
+                <li><strong>Appareil</strong> : smartphone ou tablette exécutant l’application Lifelight. </li>
+                <li><strong>Logiciel du dispositif médical</strong> : l’application Lifelight exécutée sur l’appareil connecté à l’algorithme distant qui renvoie les résultats. </li>
+            </ul>
+        </div>
+
+        <h2>Avertissements et affirmations pouvant apparaître dans l’application</h2>
+        <p> Les avertissements et les affirmations qui peuvent apparaître dans l’application ou dans le présent document.</p>
+        <p></p>
+        <p>L’application est sans danger pour les patients et les médecins lorsqu’elle est utilisée en conformité avec les instructions et les avertissements détaillés dans les présentes instructions d’utilisation.</p>
+        <p>Avant d’utiliser l’application, vous devez vous familiariser avec tous les avertissements afin de vous assurer d’une bonne qualité du signal de mesure et de l’utilisabilité des mesures.</p>
+        <p>En plus d’examiner les avertissements généraux présentés dans la section suivante, vous devez également passer en revue les instructions spécifiques figurant dans les sections Préparation et mise en place, Prendre une mesure et Maintenance. </p>
+        <ul>
+            <li class="strong">La mauvaise compréhension ou le non-respect des avertissements contenus dans le présent manuel peut entraîner une mauvaise qualité du signal, une absence de mesure ou des résultats inexacts.</li>
+        </ul>
+        <h2 class="strong">Faible qualité de la mesure</h2>
+        <p class="strong">Faible qualité de la mesure, entraînant une absence de résultat à la fin de la mesure et pouvant survenir pour une ou plusieurs des causes suivantes :</p>
+        <h3>Éclairage</h3>
+        <ol>
+            <li>Le sujet (la personne sur laquelle les mesures sont effectuées) est mal éclairé.</li>
+            <li>Le sujet est fortement éclairé par l’arrière ou par le haut et n’est pas suffisamment éclairé par l’avant.</li>
+            <li>L’arrière-plan du sujet est très lumineux.</li>
+            <li>Un miroir ou une surface réfléchissante se trouve derrière le sujet.</li>
+            <li>Des ombres importantes sont présentes sur le front et sur les joues du sujet.</li>
+            <li>La lumière varie pendant la mesure. Outre le scintillement d’une lumière, ce cas peut être entraîné par le déplacement d’objets ou de personnes à l’arrière-plan. </li>
+        </ol>
+        <h3>Mouvement</h3>
+        <ol>
+            <li>L’appareil subit trop de mouvement pendant la mesure. S’il vous est impossible de maintenir l’appareil immobile, évitez de le tenir à la main et utilisez plutôt un support ou appuyez-le contre un objet. </li>
+            <li>Le sujet peut bouger de manière excessive, en parlant ou en regardant autour de lui pendant la mesure, par exemple. (Le clignement des yeux et les légers mouvements liés à la respiration ne devraient pas affecter la MSQ.)</li>
+            <li>Un sujet atteint du syndrome de Gilles de la Tourette peut bouger lors de la mesure. Il est donc recommandé d’utiliser d’autres outils de mesure.</li>
+        </ol>
+        <h3>Autre</h3>
+        <ol>
+            <li>Il n’existe pas de connexion Wi-Fi ou de données adéquate permettant de charger les données. </li>
+            <li>Le front et les joues du sujet ne sont pas visibles.</li>
+            <li>L’objectif de l’appareil n’est pas propre.</li>
+        </ol>
+    </section>
+    <div class="break"></div>
+    <!--PRINT BREAK-->
+
+    <!--closes quick start-->
+
+    <section id="what"> <!--what ll does-->
+        <h3>Définition et fonctionnement de Lifelight</h3>
+        <div class="">
+            <p>Lifelight est une application logicielle constituant un dispositif médical. Elle est destinée à servir de moyen simple pour estimer le pouls et la pression artérielle en 60 secondes ou moins. Grâce à la caméra de l’appareil, le logiciel mesure les changements de couleur de la peau du visage à chaque battement du cœur. Une fois les informations colorimétriques traitées, le logiciel fournit des mesures de la fréquence cardiaque et de la pression artérielle.</p>
+        </div>
+    </section>
+    <section id="benefits"> <!--benefits-->
+        <h2>Bénéfices cliniques</h2>
+        <p><strong>Bénéfice 1.</strong> Lifelight mesure simultanément le pouls et la pression artérielle. </p>
+        <p><strong>Bénéfice 2.</strong> Lifelight permet de mesurer le pouls et la pression artérielle dans des situations où les méthodes par contact ne sont pas possibles ou souhaitables. </p>
+        <p><strong>Bénéfice 3.</strong> Lifelight mesure le pouls et la pression artérielle sans utiliser de brassard et sans nécessiter d’autre appareil ou instrument, y compris à des fins de calibrage.</p>
+    </section>
+    <section id="preparation"><!--Preparation and setup-->
+        <h2> Préparation et mise en place de Lifelight avant la prise d’une mesure. </h2>
+        <h3>Préparation du dispositif et configuration requise.</h3>
+        <ul>
+            <li>Lifelight est conçu pour fonctionner sur toute une gamme d’appareils mobiles validés. La liste des appareils validés peut être
+                consultée à l’adresse <a href="https://lifelight.ai/validated-devices/">https://lifelight.ai/validated-devices/</a>. </li>
+            <li>Assurez-vous que le système d’exploitation de l’appareil est à jour.</li>
+            <li>Pas de calibrage requis. </li>
+            <li>Assurez-vous d’utiliser la dernière version de l’application Lifelight.</li>
+            <li>Assurez-vous que l’appareil est suffisamment chargé pour répondre à vos besoins. </li>
+            <li>Assurez-vous que les objectifs de l’appareil sont propres.</li>
+        </ul>
+        <h3>Caractéristiques des réseaux informatiques et mesures de sécurité informatique.</h3>
+        <ul>
+            <li>Lifelight nécessite une connexion stable à Internet pour fonctionner.</li>
+            <li> La connexion minimale requise est de 0,128 mb/s en débit ascendant et de 0,128 mb/s en débit descendant. </li>
+            <li>Pour que le logiciel fonctionne comme prévu, la connexion au Wi-Fi doit être sécurisée et protégée contre tout accès non autorisé.</li>
+        </ul>
+        <h3>Garder l’appareil immobile.</h3>
+        <ul>
+            <li>L’appareil sur lequel Lifelight est exécuté doit être maintenu aussi immobile que possible lors de la prise d’une mesure.</li>
+            <li>Si l’appareil est maintenu par un support reposant sur une surface, cette surface doit être libre de tout mouvement ou vibration.</li>
+            <li>Les supports idéaux permettent de repositionner et d’incliner l’appareil afin de l’adapter aux différentes tailles lorsqu’ils sont utilisés par un opérateur avec plusieurs sujets.</li>
+        </ul>
+
+        <h3>Environnement, éclairage et installations spéciales.</h3>
+        <ul>
+            <li>Pour des résultats optimaux de Lifelight, l’environnement, la pièce ou l’espace doivent être libres de toute distraction et permettre un bon éclairage du visage du sujet.</li>
+            <li>Dans l’idéal, les conditions lumineuses doivent permettre un éclairage correct du visage, sans ombres imposantes. L’utilisation de plusieurs sources lumineuses vives et diffuses est idéale.</li>
+            <li>Le fonctionnement de Lifelight peut être gêné si le visage du sujet est éclairé à partir d’une seule source lumineuse vive, susceptible de créer de fortes ombres sur le front et sur les joues. </li>
+            <li>Le fonctionnement de Lifelight peut être gêné en cas d’important contre-jour du sujet et/ou si le l’espace dans lequel il se trouve est fortement éclairé tandis que le sujet lui-même ne l’est pas.</li>
+        </ul>
+        <h3>Sujet : la personne sur laquelle les mesures sont effectuées.</h3>
+        <ul>
+            <li>Lifelight est validé pour les sujets âgés de 18 ans et plus. </li>
+            <li>Le fonctionnement de Lifelight implique de mesurer la couleur de la peau sur les joues et le front. Par conséquent, ces zones du visage du sujet doivent être visibles et bien éclairées.</li>
+            <li>Les sujets doivent retirer leurs lunettes, leur chapeau ou leur foulard si ceux-ci sont susceptibles de masquer la peau du visage ou de projeter des ombres importantes. </li>
+            <li>Les sujets doivent coiffer leurs cheveux de manière à ce que la peau de leur visage soit exposée et sans ombres. </li>
+            <li>Si la situation clinique le permet, retirer tout masque (comme un masque à oxygène, par exemple) pour la durée de la mesure. </li>
+            <li>Certains sujets peuvent craindre d’être filmés. Lifelight s’appuie exclusivement sur les images prises avec la caméra pour mesurer les valeurs numériques des couleurs de la peau sur le visage. Seules ces valeurs numériques des couleurs sont utilisées pour calculer les paramètres vitaux. Les images sont supprimées. </li>
+            <li>Les sujets doivent éviter la nourriture, la caféine, le tabac et l’alcool pendant une période d’au moins 1 heure avant la prise d’une mesure. </li>
+            <li>Les sujets doivent s’asseoir au calme pendant quelques minutes avant la prise de la mesure.</li>
+            <li>Les sujets doivent être détendus, leur dos et leurs pieds doivent être appuyés, et leurs bras et leurs jambes ne doivent pas être croisés.</li>
+        </ul>
+    </section>
+    <!--closes preparation and setup-->
+    <section id="measurement"><!--Taking a measurement-->
+
+        <h2>Prendre une mesure</h2>
+        <p>S’assurer que les étapes de <strong>préparation et de mise en place</strong> décrites ci-dessus ont été suivies.</p>
+        <h3>Veuillez saisir vos informations biométriques : sexe, âge et taille</h3>
+        <ul>
+            <li>Veuillez saisir votre âge, votre taille et votre sexe, puis appuyez sur Envoyer</li>
+            <li>Pour la taille, appuyez sur cm/pieds pour alterner entre les unités métriques et impériales.</li>
+            <li>Le démarrage de la lecture ne sera possible que lorsque les valeurs biométriques seront toutes
+                saisies.
+            </li>
+            <li>Après avoir saisi vos données biométriques, vous recevrez des instructions sur la manière de réaliser la mesure
+                Lifelight.</li>
+        </ul>
+        <h3>Prendre une mesure</h3>
+        <ul>
+            <li>Centrez votre visage sur l’écran ; un rectangle blanc apparaîtra.</li>
+            <li>Un guidage apparaîtra à l’écran, qui vous aidera à positionner votre visage correctement et proposera
+                des recommandations concernant l’éclairage et les mouvements de l’appareil
+            </li>
+            <li>Lorsque vous vous trouvez dans la bonne position, la lecture Lifelight démarre</li>
+            <li>La lecture prend 40 secondes. Un compte à rebours s’affiche en haut de l’écran et indique
+                le temps nécessaire à la lecture.
+            </li>
+            <li>Restez immobile pendant la durée de la lecture.</li>
+            <li>Vous pouvez arrêter une lecture à tout moment en appuyant sur le bouton Annuler situé en bas de l’écran.</li>
+            <li>Une fois les 40 secondes écoulées, les résultats de votre lecture s’affichent</li>
+        </ul>
+    </section>
+    <section id="retake"><!--When to retake a measurement-->
+        <h2>Quand reprendre une mesure ?</h2>
+        <div>
+            <p>Vous pouvez reprendre une mesure si vous avez des raisons de soupçonner une mauvaise mesure.</p>
+            <p>Il est possible d’annuler la mesure avant sa conclusion et de la redémarrer.</p>
+            <ul>
+                <li> Reprenez la mesure si la qualité globale de la mesure est faible. (Lorsque la qualité globale de lecture
+                    est faible, aucun résultat ne s’affichera.)</li>
+                <li>Reprendre si le sujet bouge ou parle lors de la mesure.</li>
+                <li>Reprendre si la table ou le support sont frappés ou déplacés lors de la mesure.</li>
+                <li>Reprendre si la lumière est interrompue ou varie ; cela peut se produire si un objet ou une personne passe devant la source de lumière ou si l’éclairage est allumé ou éteint.</li>
+            </ul>
+        </div>
+    </section>
+    <div class="break"></div>
+    <!--PRINT BREAK-->
+    <section id="accuracy"><!--Measuring degree of accuracy-->
+        <h2>Mesure du degré de précision</h2>
+        <div>
+            <h3>Fréquence cardiaque</h3>
+            <p>Mesure de la fréquence cardiaque avec une exactitude et une précision de 1,34 battement par minute d’erreur rms pour une plage validée de 52 à 111 BPM.</p>
+            <h3>Pression artérielle systolique</h3>
+            <p>Mesure de la pression artérielle systolique avec une exactitude et une précision d’erreur moyenne (sd) de 6,68 (±15,57) mmHg pour une plage validée de 81 à 192 mmHg.</p>
+            <h3><strong>Pression artérielle diastolique</strong></h3>
+            <p>Mesure de la pression artérielle diastolique avec une exactitude et une précision d’erreur moyenne (sd) de -0,10 (±11,80) mmHg pour une plage validée de 48 à 107 mmHg.</p>
+            <h3>Validation</h3>
+            <p>Les données sont basées sur les résultats de l’étude de validation clinique de la pression artérielle et de la fréquence cardiaque non invasives de Lifelight (Lifelight Pivotal Clinical Investigation, étude 001).<u></u><u></u></p>
+        </div>
+    </section>
+    <section id="technical"><!--Setting screen-->
+        <h2>Description technique</h2>
+        <div>
+            <p>Lifelight ne fonctionne que sur des appareils validés. La liste des appareils validés peut être
+                consultée à l’adresse <a href="https://lifelight.ai/validated-devices/">https://lifelight.ai/validated-devices/</a>.</p>
+            <p>Lors de l’installation, il vous sera demandé d’autoriser l’accès à la caméra de l’appareil. Vous devez accepter cette demande, sinon Lifelight ne fonctionnera pas. </p>
+            <p>Une fois installé, Lifelight est entièrement configuré et ne nécessite aucune configuration ou calibrage. </p>
+            <p>Lifelight utilise la lumière réfléchie par le visage pour prendre une mesure. Il doit donc être utilisé lorsque le visage du sujet est bien éclairé. La température et l’humidité (dans la mesure où elles n’affectent pas l’éclairage du sujet) n’interféreront pas avec le fonctionnement de Lifelight. </p>
+            <p>Lifelight communique avec un serveur sécurisé hébergé par Amazon Web Services (AWS) afin de calculer les paramètres vitaux affichés. Pour fonctionner, l’application Lifelight nécessite une connexion Internet de bonne qualité, avec un signal Wi-Fi puissant. Au lancement et avant la prise d’une mesure, Lifelight teste la force de la connexion et ne permettra pas de prendre une mesure (et affichera un avertissement) si la connexion est trop faible. Si la connexion échoue ou est corrompue de quelque manière que ce soit, la lecture échoue et un message d’avertissement s’affiche. </p>
+            <p>En dehors de l’accès à Internet, Lifelight n’a aucune autre exigence en termes de réseau. En tant qu’application autonome, Lifelight ne se connecte à aucun autre réseau ou service informatique. </p>
+            <p>Les données sont envoyées au serveur de manière sécurisée par un canal chiffré, sont stockées de manière sécurisée sur le système AWS et ne contiennent aucune donnée personnellement identifiable (DPI). Les seules données envoyées sont l’âge, la taille, le sexe et la couleur moyenne du visage du sujet (mesurée 30 fois par seconde). </p>
+        </div>
+    </section>
+    <div class="break"></div>
+    <!--PRINT BREAK-->
+    <section id="other"><!--Other-->
+        <h2>Autre</h2>
+        <div>
+            <div>
+                <h3>Maintenance/fréquence</h3>
+                <p>Lancer les mises à jour du logiciel et du système d’exploitation de l’appareil lorsque de nouvelles versions sont disponibles. </p>
+            </div>
+            <div>
+                <h3>Incident grave</h3>
+                <p>Tout incident grave survenu en rapport avec le dispositif doit être signalé au fabricant et aux autorités compétentes de l’État membre dans lequel l’utilisateur et/ou le patient est établi.</p>
+            </div>
+        </div>
+        <h3>Résolution de problèmes/précautions à prendre en cas de dysfonctionnement</h3>
+        <table class="blueTable">
+            <colgroup><col width="50%">
+            </colgroup><thead>
+        <tr>
+            <th>Situation</th>
+            <th>Réponse</th>
+        </tr>
+        </thead>
+            <tbody>
+            <tr>
+                <td class="table-align-top"><p>L’application se bloque.</p></td>
+                <td><p>Les résultats ne seront pas retournés à la fin d’une mesure. Sortir et redémarrer l’application ou l’appareil hôte.</p></td>
+            </tr>
+            <tr>
+                <td><p>Utilisation impossible en raison de l’absence de connexion de données ou de signal Wi-Fi.</p></td>
+                <td><p>Trouver ou attendre le signal, puis redémarrer. Ou utiliser des méthodes conventionnelles alternatives.</p></td>
+            </tr>
+            <tr>
+                <td><p>La caméra ne propose pas une image claire en raison de la présence de saleté ou de condensation.</p></td>
+                <td class="table-align-top"><p>Nettoyer l’objectif.</p></td>
+            </tr>
+            </tbody>
+        </table>
+        <p> </p>
+        <h3>Mise hors service et élimination du logiciel.</h3>
+        <p>L’application peut être supprimée de l’appareil en utilisant la méthode standard de suppression des applications pour la plateforme. Dans le cas où Lifelight est supprimée, aucune information ne sera conservée sur l’appareil.</p>
+    </section>
+    <p><em>Avant d’utiliser le présent produit, le professionnel de la santé doit étudier attentivement les indications, l’utilisation prévue, les recommandations, les avertissements et les instructions, ainsi que les informations spécifiques disponibles pour le produit. Xim Ltd n’est pas responsable des problèmes pouvant découler d’une utilisation du dispositif hors du cadre des utilisations indiquées ou de problèmes similaires situés hors du contrôle de xim Ltd.</em></p>
+    <p><em>Les informations fournies dans les présentes instructions d’utilisation sont destinées aux professionnels de la santé ou à un patient qui a reçu les instructions d’un professionnel de la santé.</em></p>
+    <p><em>Pour toute question ou information supplémentaire concernant les présentes instructions d’utilisation, veuillez nous contacter sur www.lifelight.ai</em></p>
+
+    <div class="column2">
+        <img src="img/factory.svg" alt="usine" width="40px">
+        <p><strong>XIM Ltd.<br>
+            University of Southampton Science Park<br>
+            2 Venture Road<br>
+            Southampton<br>
+            Hampshire<br>
+            Royaume-Uni<br>
+            SO16 7NP</strong></p>
+        <img src="img/ecrep.svg" alt="usine" width="90px">
+        <p><strong> Arazy Group (Ireland) Ltd<br>
+        </strong><strong>19 Baggot Street Lower,<br>
+            Dublin 2<br>
+            D02 X658<br>
+            Irlande<br>
+            ireland@arazygroup.com</strong></p>
+    </div>
+
+    <!--<div class="column2">
+        <img src="img/importer.png" alt="importateur" width="40px">
+        <p><strong>Importateur au sein de l’Union européenne<br>
+            MedEnvoy Global B.V. <br>
+            Prinses Margrietplantsoen 33 – Suite 123 2595 AM <br>
+            La Haye <br>
+            Pays-Bas.<br>
+            Importer@MedEnvoyGlobal.com</strong></p>
+    </div>-->
+
+    <div>
+        <img src="img/chrep.svg" alt="chrep" width="90px">
+        <p><strong> MedEnvoy Switzerland <br>
+        </strong><strong>Gotthardstrasse 28<br>
+            6302 Zug<br>
+            Switzerland</strong></p>
+    </div>
+
+    <div class="column2">
+        <img src="img/importer.png" alt="importateur" width="40px">
+        <p><strong>Importateur en Suisse<br>
+            Sanitas <br>
+            Sanitas Management AG, <br>
+            Jägergasse 3, <br>
+            8004<br>
+            Zurich<br>
+            Suisse</strong></p>
+    </div>
+
+    <!--<div class="column2">
+        <img src="img/importer.png" alt="importateur" width="40px">
+        <p><strong>Importateur et représentant autorisé en Thaïlande <br>
+            Kitmeechai Trading Co., Ltd.<br>
+            Lasalle Tower, 5th Floor, 10/11 Moo 16 Lasalle Road, <br>
+            Bang Kaeo Subdistrict, Bang Phli District,<br>
+            Samut Prakan, 10540<br>
+            Thaïlande</strong></p>
+    </div>-->
+
+    <div>
+        <img src="img/ce.svg" width="40px" alt="">
+        <img style="margin-left: 20px;" src="./Lifelight – Instructions For Use (single product)_files/medical.svg" width="50px" alt="">
+        <p><strong>0123</strong></p>
+    </div>
+</main>
+
+
+
+</body></html>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-fr.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-fr.html
@@ -459,7 +459,7 @@
 
     <div>
         <img src="img/ce.svg" width="40px" alt="">
-        <img style="margin-left: 20px;" src="./Lifelight – Instructions For Use (single product)_files/medical.svg" width="50px" alt="">
+        <img style="margin-left: 20px;" src="img/medical.svg" width="50px" alt="">
         <p><strong>0123</strong></p>
     </div>
 </main>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1.html
@@ -420,7 +420,7 @@
       ireland@arazygroup.com</strong></p>
   </div>
 
-  <div class="column2">
+  <!--<div class="column2">
     <img src="img/importer.png" alt="importer" width="40px"/>
     <p><strong>EU Importer<br>
       MedEnvoy Global B.V. <br>
@@ -428,6 +428,9 @@
       The Hague <br>
       The Netherlands.<br>
       Importer@MedEnvoyGlobal.com</strong></p>
+  </div>-->
+
+  <div>
     <img src="img/chrep.svg" alt="chrep" width="90px"/>
     <p><strong> MedEnvoy Switzerland <br>
     </strong><strong>Gotthardstrasse 28<br>
@@ -446,7 +449,7 @@
       Switzerland</strong></p>
   </div>
 
-  <div class="column2">
+  <!--<div class="column2">
     <img src="img/importer.png" alt="importer" width="40px"/>
     <p><strong>TH Importer and Authorised Rep <br>
       Kitmeechai Trading Co., Ltd.<br>
@@ -454,6 +457,9 @@
       Bang Kaeo Subdistrict, Bang Phli District,<br>
       Samut Prakan, 10540<br>
       Thailand</strong></p>
+  </div>-->
+
+  <div>
     <img src="img/ce.svg" width="40px" alt=""/>
     <img style="margin-left: 20px;" src="img/medical.svg" width="50px" alt=""/>
     <p><strong>0123</strong></p>

--- a/ifu/ll-ifu/ll-singleproduct-label-fr.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-fr.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<!-- saved from url=(0070)https://xim-lifelight.github.io/ifu/ll-ifu/ll-singleproduct-label.html -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-173128924-1');
+    </script>
+
+    <title>Lifelight – Étiquette (produit unique)</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="llifu-styles.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+
+<main class="centred">
+    <section id="logo"><!--top plate info -->
+        <div class="column-holder">
+            <div class="column2"> <img src="img/date.svg" width="40px" alt="">
+                <p><strong>11 2023</strong></p>
+                <img src="img/factory.svg" alt="usine" width="40px">
+                <p><strong>XIM Ltd.<br>
+                    University of Southampton Science Park<br>
+                    2 Venture Road<br>
+                    Southampton<br>
+                    Hampshire<br>
+                    Royaume-Uni<br>
+                    SO16 7NP</strong></p>
+                <img src="img/ecrep.svg" alt="usine" width="90px">
+                <p><strong> Arazy Group (Ireland) Ltd<br>
+                </strong><strong>19 Baggot Street Lower,<br>
+                    Dublin 2<br>
+                    D02 X658<br>
+                    Irlande<br>
+                    ireland@arazygroup.com</strong></p>
+
+                <!--<img src="img/importer.png" alt="importateur" width="40px">
+                <p><strong>Importateur UE<br>
+                    MedEnvoy Global B.V. <br>
+                    Prinses Margrietplantsoen 33 – Suite 123 2595 AM <br>
+                    La Haye<br>
+                    Pays-Bas.<br>
+                    Importer@MedEnvoyGlobal.com</strong></p>-->
+                <img src="img/chrep.svg" alt="chrep" width="90px">
+                <p><strong> MedEnvoy Switzerland <br>
+                </strong><strong>Gotthardstrasse 28<br>
+                    6302 Zug<br>
+                    Switzerland</strong></p>
+
+                <img src="img/importer.png" alt="importateur" width="40px">
+                <p><strong>Importateur en Suisse<br>
+                    Sanitas <br>
+                    Sanitas Management AG, <br>
+                    Jägergasse 3, <br>
+                    8004<br>
+                    Zurich<br>
+                    Suisse</strong></p>
+
+                <!--<img src="img/importer.png" alt="importateur" width="40px">
+                <p><strong>Importateur et représentant autorisé en Thaïlande <br>
+                    Kitmeechai Trading Co., Ltd. <br>
+                    Lasalle Tower, 5th Floor, 10/11 Moo 16 Lasalle Road,<br>
+                    Bang Kaeo Subdistrict, Bang Phli District,<br>
+                    Samut Prakan, 10540<br>
+                    Thaïlande</strong></p>-->
+            </div>
+
+            <div class="column2"> <img src="img/ce.svg" width="40px" alt="">
+                <img style="margin-left: 20px;" src="img/medical.svg" width="50px" alt="">
+                <p><strong>0123</strong></p>
+                <p><img src="img/ll-qr.svg" alt="ll-qr" width="150px"></p>
+                <p class="small">(01)05060776720019<br>
+                    (11)231106<br>
+                    (21)LLF-002<br>
+                    (8012)5.0.0-0</p>
+                <p><strong>Identifiant unique de l’appareil :</strong><br>
+                    05060776720019</p>
+            </div>
+        </div>
+    </section>
+    <div>
+        <section id="intended"> <!--Intended use-->
+            <h2>Utilisation prévue/instructions d’utilisation de Lifelight</h2>
+            <div>
+                <p>Le logiciel du dispositif médical sans contact Lifelight est destiné à la mesure non invasive de la pression artérielle (mmHg) et de la fréquence du pouls (bpm) chez les patients adultes âgés de 18 ans et plus, indépendamment de leur origine ethnique ou de leur sexe. Le logiciel n’est pas destiné aux femmes enceintes, à un usage pédiatrique ou aux personnes souffrant de fibrillation auriculaire ou de conditions de faible perfusion telles que l’anémie, la jaunisse, les taches de naissance, la rosacée, le psoriasis, l’acné aiguë ou la protoporphyrie érythropoïétique. Lifelight mesure les paramètres physiologiques vitaux par une méthode appelée photopléthysmographie à distance (rPPG), qui est un moyen non invasif de détecter le pouls du volume sanguin cardiovasculaire (BVP) par de petites variations de la lumière réfléchie par la surface de la peau. Lifelight fonctionne en utilisant la caméra d’un appareil mobile pour détecter les changements de couleur infimes de la peau du visage d’un patient provoqués par les battements de son cœur.</p>
+                <p><strong>Population de Patients visée :</strong><br>
+                    Patients adultes âgés de 18 ans et plus, indépendamment de leur origine ethnique ou de leur sexe. Le présent logiciel de dispositif médical n’est pas destiné aux femmes enceintes, à un usage pédiatrique ou aux personnes souffrant de fibrillation auriculaire ou de conditions de faible perfusion telles que l’anémie, la jaunisse, les taches de naissance, la rosacée, le psoriasis, l’acné aiguë ou la protoporphyrie érythropoïétique.</p>
+                <p><strong>Environnements d’utilisation et utilisateurs visés :</strong><br>
+                    Les contextes d’utilisation les plus probables sont les hôpitaux, les cliniques, les résidences médicalisées, tout autre structure de soin de santé et le domicile du patient.</p>
+                <p>Le logiciel Lifelight doit être utilisé par des professionnels de la santé ou par un patient qui a reçu les instructions d’un professionnel de la santé.</p>
+                <p>Lifelight est indiqué pour une utilisation sur des patients au repos, immobiles, dans un environnement bien éclairé.</p>
+                <h3><strong>Contre-indications, effets indésirables, informations utiles, remarques importantes concernant l’utilisation du logiciel Lifelight, mises en garde, avertissements et précautions :</strong></h3>
+                <p><strong>Contre-indications :</strong><br>
+                    Lifelight n’a pas été validé pour une utilisation chez les femmes enceintes ou les personnes souffrant de fibrillation auriculaire. Nous conseillons donc de ne pas utiliser Lifelight sur ces types de sujets.</p>
+                <p>Lifelight n’est pas recommandé pour les personnes souffrant de conditions de faible perfusion telles que l’anémie, la jaunisse, les taches de naissance, la rosacée, le psoriasis, l’acné aiguë ou la protoporphyrie érythropoïétique.</p>
+                <p><strong>Effets indésirables :</strong><br>
+                    Aucun effet ou réaction indésirable n’est connu, attendu ou prévisible dans le cadre de l’utilisation de Lifelight, qui est un logiciel de dispositif médical.</p>
+                <p><strong>Informations utiles :</strong><br>
+                    Sachez que les paramètres vitaux peuvent fluctuer en fonction de légères modifications dans le corps et de l’heure de la journée. Une valeur constante au fil du temps est très inhabituelle. En cas de mesure régulière des paramètres vitaux, par exemple, de la pression artérielle sur plusieurs jours, l’idéal est de prendre les mesures à des horaires et dans des conditions identiques.</p>
+                <p>Si une mesure donne des résultats qui vous paraissent anormaux, mais que l’utilisateur se sent bien, ne paniquez pas : cela peut arriver. Il est important de se détendre pendant 5 minutes avant de mesurer à nouveau les paramètres vitaux. Une pression artérielle basse (hypotension), une pression artérielle élevée (hypertension), les raisons d’une fréquence cardiaque constamment rapide (tachycardie) ou constamment lente (bradycardie), ou d’une fréquence respiratoire inhabituelle ne peuvent être diagnostiquées que par un professionnel de la santé qualifié. Il est conseillé à la personne de contacter son médecin traitant ou son pharmacien si elle a des inquiétudes concernant les résultats.</p>
+                <p>Pour obtenir les valeurs les plus précises possibles, vous devez attendre au moins une heure après avoir mangé, fumé, consommé de la caféine, de l’alcool ou fait de l’exercice physique. Ces facteurs peuvent en effet affecter vos résultats. Restez détendu(e) et immobile pendant la mesure.</p>
+                <p><strong>Remarques importantes concernant l’utilisation :</strong><br>
+                    Lifelight est uniquement destiné à l’usage décrit dans les instructions d’utilisation. Le fabricant n’est pas responsable des dommages résultant d’une utilisation inappropriée ou négligente.</p>
+                <p>Dans les cas où une lecture de pouls forte n’est pas détectée par le logiciel, aucune mesure des paramètres vitaux ne sera renvoyée. </p>
+                <p><strong>Mises en garde :</strong><br>
+                    Le présent logiciel est destiné à la mesure non invasive de la pression artérielle (mmHg) et de la fréquence du pouls (bpm) chez les patients adultes âgés de 18 ans et plus, indépendamment de leur origine ethnique ou de leur sexe. Il n’est pas destiné au traitement d’une affection médicale spécifique, mais à faciliter le diagnostic ou le traitement de ces affections médicales lorsque la mesure des paramètres vitaux est nécessaire.</p>
+                <p><img src="img/caution.svg" alt="mise en garde" width="30px" class="inline-shift"><strong>Avertissements :</strong><br>
+                    Le présent logiciel ne dispose pas d’alarme en cas de dépassement des limites. Ne pas utiliser dans des situations où des alarmes sont nécessaires.</p>
+                <p><strong>Précautions :</strong><br>
+                    Lifelight n’a pas été testé sur des personnes présentant les conditions suivantes, qui peuvent interférer avec les mesures. Nous recommandons donc d’utiliser un autre outil de mesure dans les cas suivants :</p>
+                <ul>
+                    <li>Sujets présentant des arythmies cardiaques persistantes.</li>
+                    <li>Sujets présentant un taux de mélanine élevé.</li>
+                    <li>Sujets présentant des tatouages faciaux.</li>
+                    <li>Sujets ayant subi une chirurgie plastique faciale.</li>
+                    <li>Sujets ayant reçu des injections de botox.</li>
+                    <li>Sujets présentant des cicatrices faciales ou des lambeaux cutanés.</li>
+                    <li>Sujets présentant une hypothermie.</li>
+                    <li>Sujets présentant une hyperthermie.</li>
+                    <li>Sujets souffrant de migraine. </li>
+                </ul>
+            </div>
+
+        </section>
+    </div>
+</main>
+
+
+</body></html>

--- a/ifu/ll-ifu/ll-singleproduct-label.html
+++ b/ifu/ll-ifu/ll-singleproduct-label.html
@@ -40,13 +40,13 @@
           Ireland<br>
           ireland@arazygroup.com</strong></p>
 
-        <img src="img/importer.png" alt="importer" width="40px"/>
+        <!--<img src="img/importer.png" alt="importer" width="40px"/>
         <p><strong>EU Importer<br>
           MedEnvoy Global B.V. <br>
           Prinses Margrietplantsoen 33 – Suite 123 2595 AM <br>
           The Hague <br>
           The Netherlands.<br>
-          Importer@MedEnvoyGlobal.com</strong></p>
+          Importer@MedEnvoyGlobal.com</strong></p>-->
         <img src="img/chrep.svg" alt="chrep" width="90px"/>
         <p><strong> MedEnvoy Switzerland <br>
         </strong><strong>Gotthardstrasse 28<br>
@@ -62,13 +62,13 @@
           Zürich<br>
           Switzerland</strong></p>
 
-          <img src="img/importer.png" alt="importer" width="40px"/>
+          <!--<img src="img/importer.png" alt="importer" width="40px"/>
           <p><strong>TH Importer and Authorised Rep <br>
             Kitmeechai Trading Co., Ltd. <br>
             Lasalle Tower, 5th Floor, 10/11 Moo 16 Lasalle Road,<br>
             Bang Kaeo Subdistrict, Bang Phli District,<br>
             Samut Prakan, 10540<br>
-            Thailand</strong></p>
+            Thailand</strong></p>-->
       </div>
 
       <div class="column2"> <img src="img/ce.svg" width="40px" alt=""/>

--- a/privacy-policy/lifelight-privacy-policy-fr.html
+++ b/privacy-policy/lifelight-privacy-policy-fr.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html>
-<head>
+<!-- saved from url=(0076)https://xim-lifelight.github.io/privacy-policy/lifelight-privacy-policy.html -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-173128924-1"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
@@ -11,326 +10,560 @@
         gtag('config', 'UA-173128924-1');
     </script>
 
-    <meta charset="UTF-8">
-    <title>Lifelight Privacy Policy - French</title>
+
+    <title>Politique de confidentialité de Lifelight</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,700&display=swap"
-          rel="stylesheet">
     <link href="ll-privacy-policy.css" rel="stylesheet" type="text/css">
 </head>
 
 <body>
 <main class="centred">
     <section> <!--cover & title-->
-        <h1>Politique de confidentialité</h1>
+        <h1>Avis de confidentialité</h1>
     </section>
-    <p><strong>Date de la dernière révision:</strong> août 2024</p>
-    <p><strong>Objectif:</strong> nous prenons très au sérieux nos responsabilités en tant que dépositaires de vos données. Cet avis de confidentialité indique quelles informations personnelles nous recueillons, comment nous les utilisons et décrit vos droits en ce qui concerne ces données.</p>
+    <p><strong>Date de la dernière révision :</strong> août 2024</p>
+    <p><strong>Objectif :</strong> nous prenons très
+        au sérieux nos responsabilités en tant que dépositaires de vos données.
+        Le présent avis de confidentialité indique quelles informations personnelles nous recueillons, comment nous les utilisons
+        et décrit vos droits en ce qui concerne ces données.</p>
+    <p>Vous avez la responsabilité de vous assurer que toutes les personnes accédant à l’application Lifelight à partir de
+        votre
+        appareil ont pris connaissance des présentes conditions et s’y conforment.</p>
     <section>
         <h2>Table des matières</h2>
         <ol>
-            <li><a href="#introduction">Introduction</a></li>
-            <li><a href="#personal">Nos rôles dans le traitement des données personnelles</a></li>
-            <li><a href="#who">Qui sommes-nous ?</a></li>
-            <li><a href="#type">Quels types d’informations recueillons-nous ?</a></li>
-            <li><a href="#cookies">Cookies</a></li>
-            <li><a href="#how">Comment nous utilisons vos données personnelles (base légale pour le traitement)</a></li>
-            <li><a href="#your">Vos données, vos droits, vos choix</a></li>
-            <li><a href="#sharing">Partage et divulgation de vos informations personnelles</a></li>
-            <li><a href="#safeguarding">Mesures de sauvegarde</a></li>
-            <li><a href="#transfers">Transferts en dehors du Royaume-Uni/de l’UE</a></li>
-            <li><a href="#legitimate">Évaluation des intérêts légitimes</a></li>
-            <li><a href="#long">Pendant combien de temps conservons-nous vos données</a></li>
-            <li><a href="https://lifelight.ai/privacy-notice/#special">Catégories spéciales de données</a>
-            </li>
-            <li><a href="#national">National Data Opt-out</a>- Personnes concernées au Royaume-Uni uniquement</li>
-            <li><a href="#complaint">Déposer une plainte</a></li>
+            <li><a href="#introduction_fr">Introduction</a></li>
+            <li><a href="#personal_fr">Nos rôles dans le traitement des données à caractère personnel</a></li>
+            <li><a href="#who_fr">Qui sommes-nous ?</a></li>
+            <li><a href="#type_fr">Quels types d’informations recueillons-nous ?</a></li>
+            <li><a href="#cookies_fr">Cookies</a></li>
+            <li><a href="#how_fr">Comment utilisons-nous vos données à caractère personnel (base légale pour le traitement) ?</a></li>
+            <li><a href="#your_fr">Vos données, vos droits, vos choix</a></li>
+            <li><a href="#sharing_fr">Partage et divulgation de vos informations personnelles</a></li>
+            <li><a href="#safeguarding_fr">Mesures de sauvegarde</a></li>
+            <li><a href="#transfers_fr">Transferts en dehors du Royaume-Uni/de l’UE</a></li>
+            <li><a href="#legitimate_fr">Évaluation des intérêts légitimes</a></li>
+            <li><a href="#long_fr">Pendant combien de temps conservons-nous vos données ?</a></li>
+            <!--<li><a href="https://lifelight.ai/privacy-notice/#special_fr">Catégories spéciales de données</a></li>-->
+            <li><a href="#national_fr">National Data Opt-out</a> (personnes concernées au Royaume-Uni uniquement)</li>
+            <li><a href="#complaint_fr">Déposer une plainte</a></li>
         </ol>
     </section>
-    <section id="introduction">
+    <section id="introduction_fr">
         <h3>Introduction</h3>
-        <p>Nous accordons la plus grande importance à votre confidentialité et au traitement de vos données personnelles. Le présent avis de confidentialité détaille comment nous recueillons, utilisons et stockons en toute sécurité toutes les données personnelles qui nous sont soumises via l’utilisation de notre site Web (https://lifelight.ai) et de l’application Lifelight et des services fournis dans le cadre de l’application (« Application Lifelight »).  Des politiques de confidentialité distinctes s’appliqueront aux essais cliniques conformément au protocole d’essai respectif.</p>
+        <p>Nous accordons la plus grande
+            importance à votre confidentialité et au traitement de vos données à caractère personnel. Le présent avis de confidentialité détaille comment nous recueillons, utilisons et stockons en toute sécurité
+            toutes les données à caractère personnel qui nous sont soumises via l’utilisation de notre site Web (https://lifelight.ai)
+            et de l’Application Lifelight et des services fournis dans le cadre de l’application
+            (« Application Lifelight »). Des politiques de confidentialité distinctes s’appliqueront aux essais cliniques
+            conformément au protocole d’essai respectif.</p>
     </section>
-    <section id="personal">
-        <h3>Nos rôles dans le traitement de vos données personnelles</h3>
-        <p>Nous sommes ce que l’on appelle un « contrôleur de données » pour le traitement de vos données personnelles, qui nous sont transmises via notre site Web.</p>
-        <p>Pour les données de patients ou d’utilisateurs qui nous sont soumises via l’utilisation de notre application Lifelight, Xim est ce qu’on appelle le ‘processeur de données’ et non le ‘contrôleur de données’ sauf lorsque Xim est tenu de stocker vos données pour se conformer à ses obligations réglementaires, auquel cas Xim est un ‘contrôleur de données’.</p>
-        <p>Le contrôleur de données tient le rôle principal dans les décisions concernant vos données personnelles, par exemple lorsque vous exercez les droits dont vous disposez en vertu des lois sur la protection des données, bien que nous (en tant que processeur) ayons également des responsabilités en ce qui concerne la sécurité de vos données personnelles. Lorsque nous agissons en tant que ‘processeur de données’, nous partagerons vos données personnelles avec le ‘processeur de données’ tel que votre prestataire de soins de santé, des intermédiaires fournissant des services à votre prestataire de soins de santé ou à votre prestataire de services qui ont mis l’application Lifelight à votre disposition dans le cadre de leur propre produit.</p>
+    <section id="personal_fr">
+        <h3>Nos rôles dans le traitement des données à caractère personnel</h3>
+        <p>Nous sommes ce que l’on appelle un « responsable du traitement des données » pour le traitement de vos données à caractère personnel,
+            qui nous sont transmises via notre site Web.</p>
+        <p>Pour les données de patients ou d’utilisateurs qui nous sont soumises via l’utilisation de notre Application Lifelight,
+            Xim est ce qu’on appelle le « sous-traitant des données » et non le « responsable du traitement des données »,
+            sauf lorsque Xim est tenu de stocker vos données pour se conformer à ses obligations
+            réglementaires, auquel cas Xim est un « responsable du traitement des données ».</p>
+        <p>Le responsable du traitement des données tient le rôle principal dans les décisions concernant vos
+            données à caractère personnel, par exemple, lorsque vous exercez les droits dont vous disposez en vertu des lois
+            sur la protection des données, bien que nous (en tant que sous-traitant des données) ayons également des responsabilités en
+            ce qui concerne la sécurité de vos données à caractère personnel. Lorsque nous agissons en tant que « sous-traitant
+            des données », nous partagerons vos données à caractère personnel avec le « responsable du traitement des données » tel
+            que votre prestataire de soins de santé, des intermédiaires fournissant des services à votre prestataire
+            de soins de santé ou à votre prestataire de services qui ont mis l’Application Lifelight à votre disposition
+            dans le cadre de leur propre produit.</p>
     </section>
-    <section id="who">
-        <h3>Qui sommes-nous?</h3>
-        <p>Xim Limited, créateurs de Lifelight <i>(‘nous’ or ‘ou’ or ‘notre’ or ‘Xim’)</i> recueillent et traitent vos informations personnelles conformément au présent Avis de confidentialité et en conformité avec les lois applicables en matière de protection des données. Le présent Avis de confidentialité vous fournit les informations nécessaires concernant vos droits et nos obligations, et explique comment, pourquoi et quand nous traitons vos données personnelles.</p>
+    <section id="who_fr">
+        <h3>Qui sommes-nous ?</h3>
+        <p>Xim Limited, créateurs de Lifelight <i>(« nous » ou « notre » ou « nos » ou « Xim »)</i> recueillent et
+            traitent
+            vos informations personnelles conformément au présent avis de confidentialité et en
+            conformité avec les lois applicables en matière de protection des données. Le présent avis de confidentialité vous fournit
+            les informations nécessaires concernant vos droits et nos obligations,
+            et explique comment, pourquoi et quand nous traitons vos données à caractère personnel.</p>
         <p>
-            Nous sommes enregistrés en tant que 'contrôleur de données' – vous pouvez en savoir plus sur nos responsabilités en consultant le site Web de l’Information Commissioner’s Office <a
-                href="https://ico.org.uk/">ici</a>. Comme indiqué plus haut, dans certaines circonstances, nous agissons en tant que 'processeur de données' et non en tant que 'contrôleur de données'.
+            Nous sommes enregistrés en tant que « responsable du traitement des données » – vous pouvez en savoir plus sur nos
+            responsabilités en consultant le site Web de l’Information Commissioner’s Office <a href="https://ico.org.uk/">ici</a>.
+            Comme indiqué plus haut, dans certaines circonstances, nous agissons en tant que « sous-traitant des données »
+            et non en tant que « responsable du traitement des données ».
         </p>
         <p>
-            Le siège social de Xim est situé à l’adresse suivante: <b>The University of Southampton Science Park, 2
-            Venture Road, Chilworth, Southampton, Hampshire SO16 7NP</b>
+            Le siège social de Xim est situé à l’adresse suivante : <b>The University of Southampton Science Park,
+            2 Venture Road, Chilworth, Southampton, Hampshire SO16 7NP</b>
         </p>
         <p>
-            Nous sommes une société enregistrée en Angleterre et au Pays de Galles sous le numéro d’entreprise suivant: <b>3699022</b>
+            Nous sommes une société enregistrée en Angleterre et au Pays de Galles sous le numéro
+            d’entreprise suivant : <b>3699022</b>
         </p>
         <p>
-            Notre numéro d’enregistrement à l’Information Commissioner’s Office (ICO) est le suivant: <b>ZA241740</b>
+            Notre numéro d’enregistrement à l’Information Commissioner’s Office (ICO) est le suivant : <b>ZA241740</b>
         </p>
         <p>
-            Nous avons nommé un délégué à la protection des données, qui est chargé de superviser les questions relatives à cet avis de confidentialité. Si vous avez des questions concernant cet avis de confidentialité, y compris toute demande d’exercice de vos droits légaux, veuillez contacter notre délégué à la protection des données en utilisant les coordonnées ci-dessous:
+            Nous avons nommé un délégué à la protection des données, qui est chargé de superviser
+            les questions relatives au présent avis de confidentialité. Si vous avez des questions concernant le présent
+            avis de confidentialité, y compris toute demande d’exercice de vos droits légaux, veuillez contacter
+            notre délégué à la protection des données en utilisant les coordonnées ci-dessous :
         </p>
-        <p>Prior Analytics Ltd<br>
-            590 Green Lanes<br>
-            London<br>
-            N13 5RY<br>
+        <p>Prior Analytics Ltd<br>
+            590 Green Lanes<br>
+            Londres<br>
+            N13 5RY<br>
             DPO@lifelight.ai</p>
     </section>
-    <section id="type">
-        <h3>Quels types d’informations recueillons-nous?</h3>
-        <p>Les données personnelles désignent toute information relative à une personne à partir de laquelle cette personne peut être identifiée. Nous ne recueillerons jamais de données personnelles inutiles de votre part et ne traiterons pas vos informations d’une autre manière que celle déjà spécifiée dans le présent avis.</p>
+    <section id="type_fr">
+        <h3>Quels types d’informations recueillons-nous ?</h3>
+        <p>Les données à caractère personnel désignent toute information relative à une personne à partir de laquelle cette personne
+            peut être identifiée. Nous ne recueillerons jamais de données à caractère personnel inutiles de votre part
+            et ne traiterons pas vos informations d’une autre manière que celle déjà spécifiée dans le présent
+            avis.</p>
         <p>
-            Nous pouvons recueillir, utiliser, stocker et transférer différents types de données personnelles vous concernant, notamment:</p>
+            Nous pouvons recueillir, utiliser, stocker et transférer différents types de données à caractère personnel vous concernant,
+            notamment :</p>
         <ul>
             <li>Nom</li>
-            <li>Intitulé de poste</li>
+            <li>Intitulé du poste</li>
             <li>Adresse e-mail (personnelle/professionnelle)</li>
-            <li>Détails de l’organisation </li>
+            <li>Coordonnées d’entreprise</li>
             <li>Numéros de téléphone</li>
-            <li>Signes vitaux et données connexes, c’est-à-dire la fréquence cardiaque /le pouls, la pression artérielle et la respiration, ainsi que les données biométriques (taille, âge et sexe), les valeurs de pixels, les entrées/sorties dans l’application Lifelight et l’ID de mesure
+            <li>Paramètres vitaux et données connexes, c’est-à-dire la fréquence cardiaque/le pouls, la pression artérielle et
+                la respiration, ainsi que les données biométriques (taille, âge et sexe), les valeurs de pixels, les
+                entrées/sorties dans l’Application Lifelight et l’ID de mesure
             </li>
-            <li>Informations techniques sur l’utilisation de l’application Lifelight et de notre site Web (y compris l’adresse IP, l’identifiant de l’appareil, le système d’exploitation et la plateforme et d’autres technologies sur les appareils auxquels vous accédez)
+            <li>Informations techniques sur l’utilisation de l’Application Lifelight et de notre site Web
+                (y compris l’adresse IP, l’identifiant de l’appareil, le système d’exploitation et la plateforme et d’autres
+                technologies sur les appareils auxquels vous accédez)
             </li>
-            <li>Identifiant unique d’appareil, émis par Xim </li>
-            <li>Informations d’utilisation qui comprennent des informations sur la façon dont vous interagissez avec notre site Web et notre application Lifelight ou les utilisez
+            <li>Identifiant unique d’appareil, émis par Xim</li>
+            <li>Informations d’utilisation qui comprennent des informations sur la façon dont vous interagissez avec
+                notre site Web et notre application Lifelight ou les utilisez
             </li>
             <li>Préférences concernant la réception de messages marketing de notre part</li>
         </ul>
-        <p><b>Ce que nous ne recueillons PAS:</b></p>
-        <p>Les types de données suivants de votre appareil:</p>
+        <p>Ce que nous <b>ne recueillons PAS</b> :</p>
+        <p>Les types de données suivants de votre appareil :</p>
         <ul>
             <li>Images fixes</li>
             <li>Vidéo</li>
-            <li>Données audio/Son</li>
+            <li>Données audio/son</li>
         </ul>
         <p>
-            Cependant, lorsque vous utilisez l’application Lifelight, nous téléchargeons des données à partir de votre appareil, que nous utilisons pour prédire vos signes vitaux. Ces données ne contiennent que les signaux générés par la lumière réfléchie par des régions spécifiques de votre visage pendant la durée de la mesure, ainsi que vos données biométriques (âge, sexe, taille).
+            Cependant, lorsque vous utilisez l’Application Lifelight, nous téléchargeons des données à partir de votre
+            appareil, que nous utilisons pour prédire vos paramètres vitaux. Ces données ne contiennent que les signaux
+            générés par la lumière réfléchie par des régions spécifiques de votre visage pendant la durée
+            de la mesure, ainsi que vos données biométriques (âge, sexe, taille).
         </p>
-        <p><strong>Comment vos informations personnelles sont-elles recueillies?</strong></p>
-        <p>Nous recueillons vos informations lorsque vous nous les fournissez via notre formulaire de contact sur le site Web ou lorsque vous communiquez avec nous par d’autres moyens. Nous collecterons également automatiquement certaines informations lorsque vous utiliserez notre Application Lifelight, notamment des informations techniques, que nous recueillerons également automatiquement lorsque vous utiliserez notre site Web. Nous collectons ces informations techniques en utilisant des cookies. Chaque fois que vous vous abonnez à notre newsletter ou remplissez un formulaire, nous pouvons également collecter et traiter des données dans le but de fournir les services que vous utilisez.</p>
+        <p><strong>Comment vos informations personnelles sont-elles recueillies ?</strong></p>
+        <p>Nous recueillons vos informations lorsque vous nous les fournissez via notre formulaire de contact sur le site Web
+            ou lorsque vous communiquez avec nous par d’autres moyens. Nous collecterons également
+            automatiquement certaines informations lorsque vous utiliserez notre Application Lifelight,
+            notamment des informations techniques, que nous recueillerons également automatiquement lorsque vous utiliserez
+            notre site Web. Nous collectons ces informations techniques en utilisant des cookies.
+            Chaque fois que vous vous abonnez à notre newsletter ou remplissez un formulaire, nous pouvons également collecter
+            et traiter des données dans le but de fournir les services que vous utilisez.</p>
     </section>
-    <section id="cookies">
+    <section id="cookies_fr">
         <h3>Cookies</h3>
-        <p>Notre site Web et l’application Lifelight utilisent la technologie des « cookies » pour améliorer votre expérience utilisateur. Un cookie est un petit morceau de texte stocké par votre navigateur sur votre ordinateur, à la demande de notre serveur.</p>
+        <p>Notre site Web et l’Application Lifelight utilisent la technologie des « cookies » pour améliorer
+            votre expérience utilisateur. Un cookie est un petit morceau de texte stocké par votre navigateur sur
+            votre ordinateur, à la demande de notre serveur.</p>
         <p>
-            Veuillez vous référer à la <a href="https://lifelight.ai/cookie-declaration/">déclaration relative aux cookies</a> de Lifelight pour plus d’informations sur les cookies que nous utilisons.
+            Veuillez vous référer à la <a href="https://lifelight.ai/cookie-declaration/">déclaration relative aux
+            cookies</a> de Lifelight pour plus d’informations sur les cookies que nous
+            utilisons.
         </p>
     </section>
-    <section id="how">
-        <h3>Comment nous utilisons vos données personnelles (base légale et finalité du traitement)</h3>
-        <p> La loi nous oblige à disposer d’une base légale pour la collecte et l’utilisation de vos données personnelles. Nous nous appuyons sur une ou plusieurs des bases légales suivantes:</p>
+    <section id="how_fr">
+        <h3>Comment utilisons-nous vos données à caractère personnel (base légale pour le traitement) ?</h3>
+        <p> La loi nous oblige à disposer d’une base légale pour la collecte et l’utilisation de vos données
+            personnelles. Nous nous appuyons sur une ou plusieurs des bases légales suivantes :</p>
         <ul>
             <li>
-                <b>Exécution d’un contrat.</b>Lorsque nous devons exécuter le contrat que nous sommes sur le point de conclure ou que nous avons conclu avec vous.
+                <b>Exécution d’un contrat.</b>Lorsque nous devons exécuter un contrat que nous sommes sur le point
+                de conclure ou que nous avons conclu avec vous.
             </li>
             <li>
-                <b>Obligations légales.</b>Nous collectons et stockons vos données personnelles dans le cadre de notre obligation légale de respecter une obligation légale à laquelle nous sommes soumis. Nous identifierons l’obligation légale pertinente lorsque nous nous appuierons sur cette base légale.
+                <b>Obligations légales.</b>Nous collectons et stockons vos données à caractère personnel dans le cadre
+                du respect d’une obligation légale à laquelle nous sommes soumis. Nous identifierons
+                l’obligation légale pertinente lorsque nous nous appuierons sur ladite base légale.
             </li>
             <li>
-                <b>Consentement.</b>nous ne comptons sur le consentement que lorsque nous avons obtenu votre accord actif pour utiliser vos données personnelles à des fins spécifiques, par exemple si vous vous abonnez à une newsletter.
+                <b>Consentement.</b>Nous ne comptons sur le consentement que lorsque nous avons obtenu votre accord actif
+                pour utiliser vos données à caractère personnel à des fins spécifiques, par exemple, si vous
+                vous abonnez à une newsletter.
             </li>
             <li>
-                <b>Intérêts légitimes.</b>Nous pouvons utiliser vos données personnelles lorsqu’il est nécessaire de mener nos activités et de poursuivre nos intérêts légitimes. Nous nous assurons de prendre en considération et d’évaluer tout impact potentiel sur vous et vos droits (positifs comme négatifs) avant de traiter vos données personnelles pour nos intérêts légitimes. Nous n’utilisons pas vos données personnelles pour des activités où nos intérêts sont outrepassés par l’impact sur vous (sauf si nous avons votre consentement ou si la loi l’exige ou le permet). Vous avez le droit de recevoir plus d’informations sur nos intérêts légitimes : il vous suffit d’en faire la demande. Si vous souhaitez recevoir plus d’informations, veuillez nous contacter en utilisant les coordonnées indiquées ci-dessus.
+                <b>Intérêts légitimes.</b>Nous pouvons utiliser vos données à caractère personnel lorsqu’il est nécessaire de
+                mener nos activités et de poursuivre nos intérêts légitimes. Nous nous assurons de
+                prendre en considération et d’évaluer tout impact potentiel sur vous et vos droits (positifs comme
+                négatifs) avant de traiter vos données à caractère personnel pour nos intérêts légitimes.
+                Nous n’utilisons pas vos données à caractère personnel pour des activités où nos intérêts sont
+                outrepassés par l’impact sur vous (sauf si nous avons votre consentement ou si
+                la loi l’exige ou le permet). Vous avez le droit de recevoir plus d’informations
+                sur nos intérêts légitimes : il vous suffit d’en faire la demande. Si vous souhaitez recevoir plus
+                d’informations, veuillez nous contacter en utilisant les coordonnées indiquées ci-dessus.
             </li>
         </ul>
         <p><strong>
-            Les finalités et les raisons du traitement de vos données personnelles sont détaillées ci-dessous:</strong></p>
+            Les finalités et les raisons du traitement de vos données à caractère personnel sont détaillées
+            ci-dessous :</strong></p>
         <table>
-            <tr>
-                <th>Finalités / Utilisation</th>
+            <tbody><tr>
+                <th>Finalités/utilisation</th>
                 <th>Type de données</th>
                 <th>Base légale</th>
             </tr>
             <tr>
-                <td>Pour gérer notre relation avec : (a) les contacts commerciaux ; (b) les fournisseurs ; et (c) les visiteurs de notre site Web, y compris:<br>
-                    -	Vous informer des modifications apportées à l’avis de confidentialité et aux conditions de licence de l’application Lifelight.<br>
-                    -	Traiter vos demandes, réclamations et requêtes</td>
-                <td>Nom, détails de l’organisation, titre du poste et adresse e-mail professionnelle/personnelle</td>
-                <td>(a)	Exécution d’un contrat si nous avons conclu un contrat avec vous
-                    (b)	Nécessité de nous conformer à une obligation légale
-                    (c)	Intérêt légitime (fournir ou recevoir des produits ou services)
+                <td>Pour gérer notre
+                    relation avec : (a)
+                    les contacts commerciaux ; (b)
+                    les fournisseurs ; et (c) les visiteurs
+                    de notre site Web, y compris :<br>
+                    - Vous informer
+                    des modifications apportées à
+                    l’Avis de confidentialité
+                    et aux Conditions de licence
+                    de l’Application
+                    Lifelight.<br>
+                    - Traiter vos
+                    demandes,
+                    plaintes et
+                    requêtes</td>
+                <td>Nom, coordonnées
+                    d’entreprise, intitulé du poste et
+                    adresse e-mail
+                    professionnelle/personnelle</td>
+                <td>(a) Exécution d’un
+                    contrat si nous avons
+                    conclu un contrat
+                    avec vous
+                    (b) Nécessité de
+                    nous conformer à une obligation
+                    légale
+                    (c) Intérêt
+                    légitime (fournir ou
+                    recevoir des produits ou
+                    des services)
                 </td>
             </tr>
             <tr>
-                <td>Pour répondre à nos obligations réglementaires
+                <td>Pour répondre à nos obligations
+                    réglementaires
                 </td>
-                <td>Signes vitaux et données connexes, numéro d’appareil unique
+                <td>Paramètres vitaux et données
+                    connexes, numéro
+                    d’appareil unique
                 </td>
-                <td>Nécessaire pour des raisons d’intérêt public dans le domaine de la santé publique (respect de nos obligations réglementaires pour assurer la sécurité de l’application Lifelight) </td>
+                <td>Nécessaire pour des raisons
+                    d’intérêt public dans le
+                    domaine de la santé publique
+                    (respect de nos
+                    obligations réglementaires pour
+                    assurer la sécurité de
+                    l’application Lifelight)</td>
             </tr>
             <tr>
-                <td>Pour vous fournir des communications de marketing direct</td>
-                <td>Nom, détails de l’organisation, titre du poste, adresse e-mail professionnelle/personnelle et préférences marketing</td>
-                <td>Consentement </td>
+                <td>Pour vous fournir des
+                    communications
+                    de marketing direct</td>
+                <td>Nom, coordonnées
+                    d’entreprise, intitulé du poste, adresse e-mail
+                    professionnelle/personnelle
+                    et préférences
+                    marketing</td>
+                <td>Consentement</td>
             </tr>
             <tr>
-                <td>Pour administrer et protéger notre entreprise,  notre site Web et l’application Lifelight (y compris le dépannage, l’analyse des données, les tests, la maintenance du système, le support, les rapports et l’hébergement des données)</td>
-                <td>Nom, détails de l’organisation, titre du poste et adresse e-mail professionnelle/personnelle</td>
-                <td>(a)	Nécessité dans le cadre de nos intérêts légitimes (pour la conduite de nos activités, la fourniture de services administratifs et informatiques, la sécurité des réseaux, la prévention de la fraude et dans le cadre d’une réorganisation d’entreprise ou d’un exercice de restructuration du groupe)<br>
-                    (b)	Nécessité de nous conformer à une obligation légale</td>
+                <td>Pour administrer et
+                    protéger notre entreprise, notre
+                    site Web et l’Application
+                    Lifelight (y compris
+                    le dépannage, l’analyse des
+                    données, les tests, la maintenance
+                    du système, l’assistance,
+                    les rapports et l’hébergement des
+                    données)</td>
+                <td>Nom, coordonnées
+                    d’entreprise, intitulé du poste et
+                    adresse e-mail
+                    professionnelle/personnelle</td>
+                <td>(a) Nécessité dans le cadre de
+                    nos intérêts légitimes
+                    (pour la conduite de nos
+                    activités, la fourniture de
+                    services administratifs
+                    et informatiques,
+                    la sécurité
+                    des réseaux, la prévention
+                    de la fraude et dans le cadre
+                    d’une réorganisation d’entreprise ou
+                    d’un exercice de restructuration du groupe)<br>
+                    (b) Nécessité de
+                    respecter une obligation
+                    légale</td>
             </tr>
             <tr>
-                <td>Pour utiliser l’analyse de données pour améliorer notre site Web, notre application Lifelight, nos produits/services, nos relations avec la clientèle et nos expériences, et pour mesurer l’efficacité de nos communications et de notre marketing</td>
-                <td>Informations sur l’utilisation </td>
-                <td>Nécessaire à nos intérêts légitimes (pour maintenir notre site Web et l’application Lifelight à jour et pertinents, pour développer notre activité et pour éclairer notre stratégie marketing</td>
+                <td>Pour utiliser l’analyse de données pour
+                    améliorer notre site Web,
+                    notre Application Lifelight,
+                    nos produits/services,
+                    nos relations avec la clientèle
+                    et nos expériences, et pour
+                    mesurer
+                    l’efficacité de nos
+                    communications et de notre
+                    marketing</td>
+                <td>Informations techniques<br>
+                    Informations d’utilisation</td>
+                <td>Nécessaire à nos
+                    intérêts légitimes (pour
+                    maintenir notre site Web et
+                    l’Application Lifelight
+                    à jour et pertinents, pour
+                    développer notre activité et
+                    pour éclairer notre stratégie
+                    marketing</td>
             </tr>
-        </table>
+            </tbody></table>
     </section>
-    <section id="your">
+    <section id="your_fr">
         <h3>Vos données, vos droits, vos choix</h3>
         <p>
-            Chez Xim, nous voulons nous assurer que vous puissiez facilement accéder aux données que nous détenons à votre sujet et les modifier. Sous réserve de certaines restrictions, vous pouvez également faire certaines demandes concernant ces données. Veuillez nous contacter en utilisant les coordonnées indiquées ci-dessus si vous souhaitez exercer vos droits en matière de données, ou contactez le régulateur de la protection des données pour en savoir plus à leur sujet.
+            Chez Xim, nous voulons nous assurer que vous puissiez facilement accéder aux données que nous
+            détenons à votre sujet et les modifier. Sous réserve de certaines restrictions, vous pouvez également faire certaines demandes concernant
+            ces données. Veuillez nous contacter en utilisant les coordonnées indiquées ci-dessus si vous souhaitez exercer
+            vos droits en matière de données ou contactez le régulateur de la protection des données pour en savoir plus
+            à leur sujet.
         </p>
         <p><strong>
-            Le droit à l’information:
+            Le droit à l’information :
         </strong></p>
         <p>
-            Vous avez le droit de recevoir des informations claires, transparentes et facilement compréhensibles sur la manière dont nous utilisons vos informations et vos droits. C’est pourquoi nous vous fournissons les informations contenues dans le présent avis de confidentialité.
+            Vous avez le droit de recevoir des informations claires, transparentes et facilement
+            compréhensibles sur la manière dont nous utilisons vos informations et vos droits.
+            C’est pourquoi nous vous fournissons les informations contenues dans le présent avis de confidentialité.
         </p>
         <p><strong>
-            Le droit d’accès:
+            Le droit d’accès :
         </strong></p>
         <p>
-            Vous avez le droit d’accéder à vos informations (si nous les traitons) et à certaines autres informations (similaires à celles fournies dans le présent avis de confidentialité). Vous en êtes ainsi informé et vous pouvez vérifier que nous utilisons vos informations personnelles conformément à la loi sur la protection des données.
+            Vous avez le droit d’accéder à vos informations (si nous les traitons)
+            et à certaines autres informations (similaires à celles fournies dans le présent avis de confidentialité).
+            Vous en êtes ainsi informé(e) et vous pouvez vérifier que nous utilisons vos informations personnelles conformément
+            à la loi sur la protection des données.
         </p>
         <p><strong>
-            Le droit de rectification:
+            Le droit de rectification :
         </strong></p>
         <p>
-            Vous avez le droit de faire corriger vos informations si elles sont inexactes ou incomplètes, bien que nous puissions avoir besoin de vérifier l’exactitude des nouvelles données que vous nous fournissez.
+            Vous avez le droit de faire corriger vos informations si elles sont inexactes ou
+            incomplètes, bien que nous puissions avoir besoin de vérifier l’exactitude des nouvelles données que vous
+            nous fournissez.
         </p>
         <p><strong>
-            Le droit à l’effacement:
+            Le droit à l’effacement :
         </strong></p>
         <p>
-            Ceci est également connu sous le nom de 'droit à l’oubli'. En termes simples, il vous permet de demander la suppression ou l’effacement des informations que nous détenons vous concernant, et lorsqu’il n’y a aucune bonne raison pour que nous continuions à les traiter. Notez toutefois que nous ne sommes pas toujours en mesure de répondre à votre demande de suppression pour des raisons juridiques spécifiques qui vous seront notifiées, le cas échéant, au moment de votre demande.
+            Ceci est également connu sous le nom de « droit à l’oubli ». En termes simples, il vous permet de
+            demander la suppression ou l’effacement des informations que nous détenons vous concernant, et lorsqu’il
+            n’y a aucune bonne raison pour que nous continuions à les traiter. Notez toutefois que nous
+            ne sommes pas toujours en mesure de répondre à votre demande d’effacement pour des raisons juridiques spécifiques
+            qui vous seront notifiées, le cas échéant, au moment de votre demande.
         </p>
         <p><strong>
-            Le droit à la limitation du traitement:
+            Le droit à la limitation du traitement des données :
         </strong></p>
         <p>
-            Vous avez le droit de « bloquer » ou d’empêcher l’utilisation ultérieure de vos informations. Lorsque le traitement est limité, nous pouvons toujours stocker vos informations, mais nous ne les utiliserons plus, sauf dans des circonstances limitées.
+            Vous avez le droit de « bloquer » ou d’empêcher l’utilisation ultérieure de vos informations. Lorsque
+            le traitement est limité, nous pouvons toujours stocker vos informations, mais nous ne les utiliserons
+            plus, sauf dans des circonstances limitées.
         </p>
         <p><strong>
-            Le droit d’opposition au traitement:
+            Le droit de s’opposer à tout traitement :
         </strong></p>
         <p>
-            Vous avez le droit de vous opposer à certains types de traitement, y compris le traitement à des fins de marketing direct (c’est-à-dire la réception d’informations sur les produits et services de Xim qui peuvent vous intéresser par courrier électronique ou postal) ou lorsque nous nous appuyons sur un intérêt légitime comme base légale pour le traitement. Dans certains cas, nous pouvons démontrer que nous avons des motifs légitimes impérieux de traiter vos informations, qui prévalent sur votre droit d’opposition, bien que vous ayez un droit absolu d’opposition lorsque nous traitons vos données à des fins de marketing direct.
+            Vous avez le droit de vous opposer à certains types de traitement, y compris le traitement
+            à des fins de marketing direct (c’est-à-dire la réception d’informations sur les produits et services de Xim
+            qui peuvent vous intéresser par courrier électronique ou postal) ou lorsque nous nous appuyons sur un
+            intérêt légitime comme base légale pour le traitement. Dans certains cas, nous pouvons
+            démontrer que nous avons des motifs légitimes impérieux de traiter vos
+            informations, qui prévalent sur votre droit d’opposition, bien que vous ayez un droit
+            absolu d’opposition lorsque nous traitons vos données à des fins de marketing direct.
         </p>
         <p><strong>
-            Le droit à la portabilité des données:
+            Le droit à la portabilité des données :
         </strong></p>
         <p>
-            Vous avez le droit d’obtenir et de réutiliser vos informations personnelles pour vos propres besoins et ce dans différents services. Dans la mesure de nos moyens, nous fournirons vos informations dans un format facilement accessible.
+            Vous avez le droit d’obtenir et de réutiliser vos informations personnelles pour vos propres besoins
+            et ce dans différents services. Dans la mesure de nos moyens, nous fournirons vos informations dans
+            un format facilement accessible.
         </p>
         <p><strong>
-            Le droit de déposer une plainte:
+            Le droit de déposer une plainte :
         </strong></p>
         <p>
-            Vous avez le droit de déposer une plainte auprès de l’autorité nationale de protection des données sur la manière dont nous gérons ou traitons vos informations.
+            Vous avez le droit de déposer une plainte auprès de l’autorité nationale de protection des données
+            sur la manière dont nous gérons ou traitons vos informations.
         </p>
         <p><strong>
-            Le droit de retrait du consentement:
+            Le droit de retrait du consentement :
         </strong></p>
         <p>
-            Si vous avez donné votre consentement à tout ce que nous faisons avec vos informations (c’est-à-dire que nous nous appuyons sur le consentement comme base légale pour le traitement de vos informations), vous avez le droit de retirer ce consentement à tout moment.
+            Si vous avez donné votre consentement à tout ce que nous faisons avec vos informations (c’est-à-dire que nous
+            nous appuyons sur le consentement comme base légale pour le traitement de vos informations), vous avez le
+            droit de retirer ledit consentement à tout moment.
         </p>
         <p>
-            Veuillez noter que le retrait de votre consentement ne rend pas illégal ce que nous avons fait avec vos données personnelles jusqu’à ce point (lorsque votre consentement était actif).
+            Veuillez noter que le retrait de votre consentement ne rend pas illégal ce que nous avons
+            fait avec vos données à caractère personnel jusqu’à ce moment (lorsque votre consentement était actif).
         </p>
         <p>
-            Si nous recevons une demande de votre part pour exercer l’un des droits ci-dessus, nous pouvons vous demander de vérifier votre identité avant de donner suite à la demande correspondante ; ceci afin de garantir la protection et la sécurité de vos données. Nous pouvons également vous contacter pour vous demander des informations complémentaires concernant votre demande afin d’accélérer notre réponse.
+            Si nous recevons une demande de votre part pour exercer l’un des droits ci-dessus, nous pouvons vous demander
+            de vérifier votre identité avant de donner suite à la demande correspondante ; ceci afin de garantir
+            la protection et la sécurité de vos données. Nous pouvons également vous contacter pour vous demander des informations
+            complémentaires concernant votre demande afin d’accélérer notre réponse.
         </p>
     </section>
-    <section id="sharing">
+    <section id="sharing_fr">
         <h3>Partage et divulgation de vos informations personnelles</h3>
         <p>
-            Xim ne vend, n’échange ou ne loue pas vos informations à des tiers. Nous partagerons vos informations avec les fournisseurs de services travaillant en notre nom, ou pour répondre à certaines autres exigences, telles que le respect de la loi. Nous ne partagerons jamais vos informations avec des tiers à des fins de marketing, de publicité ou à toute autre fin.
+            Xim ne vend, n’échange ou ne loue pas vos informations à des tiers. Nous partagerons
+            vos informations avec les fournisseurs de services travaillant en notre nom, ou pour répondre à certaines
+            autres exigences, telles que le respect de la loi. Nous ne partagerons jamais vos
+            informations avec des tiers à des fins de marketing, de publicité ou à toute autre
+            fin.
         </p>
         <p>
-            Il se peut que nous partagions des informations avec:<br>
-            -	nos conseillers professionnels (notamment avocats, banquiers, auditeurs et assureurs).<br>
-            -	nos prestataires de services et fournisseurs (par exemple, fournisseur d’hébergement).
+            Nous pouvons partager vos informations avec :<br>
+            - nos conseillers professionnels (notamment avocats, banquiers, auditeurs et
+            assureurs).<br>
+            - nos prestataires de services et fournisseurs (par exemple, fournisseur d’hébergement).
         </p>
         <p>
-            Veuillez noter que nous sommes tenus de partager les informations nécessaires pour nous conformer aux lois et réglementations applicables. Par exemple, nous pourrions avoir besoin de partager vos informations avec les régulateurs.
+            Veuillez noter que nous sommes tenus de partager les informations nécessaires pour nous conformer aux
+            lois et réglementations applicables. Par exemple, nous pourrions avoir besoin de partager vos
+            informations avec les régulateurs.
         </p>
         <p>
-            Nous pouvons partager vos informations avec des tiers auprès desquels nous pouvons rechercher un investissement ou à qui nous pouvons choisir de vendre, de transférer ou de fusionner des parties de notre entreprise ou de nos actifs. Alternativement, nous avons la possibilité d’acquérir d’autres entreprises ou de fusionner avec elles. En cas de changement de propriétaire de l’entreprise, les nouveaux propriétaires pourront utiliser vos données personnelles pour les mêmes raisons que celles spécifiées dans le présent avis de confidentialité.
+            Nous pouvons partager vos informations avec des tiers auprès desquels nous pouvons rechercher
+            un investissement ou à qui nous pouvons choisir de vendre, de transférer ou de fusionner des parties de notre
+            entreprise ou de nos actifs. Alternativement, nous pouvons chercher à acquérir d’autres entreprises ou
+            à fusionner avec elles. Si il y a un changement de propriétaires de l’entreprise, ils pourront
+            utiliser vos données à caractère personnel pour les mêmes raisons que celles spécifiées dans le présent avis de confidentialité.
         </p>
         <p>
-            Nous demandons aux tiers de respecter la sécurité de vos informations et de les traiter conformément à la loi. Nous n’autorisons pas nos fournisseurs de services à utiliser vos informations à leurs propres fins et ne leur permettons de traiter vos informations qu’à des fins spécifiques et conformément à nos instructions.
+            Nous demandons aux tiers de respecter la sécurité de vos informations et de
+            les traiter conformément à la loi. Nous n’autorisons pas nos fournisseurs de services à utiliser
+            vos informations à leurs propres fins et ne leur permettons de traiter vos
+            informations qu’à des fins spécifiques et conformément à nos instructions.
         </p>
         <p>
-            Pour plus d’informations sur les personnes avec lesquelles vos informations personnelles sont partagées, veuillez nous contacter en utilisant les coordonnées indiquées ci-dessus.
+            Pour plus d’informations sur les personnes avec lesquelles vos informations personnelles sont partagées,
+            veuillez nous contacter en utilisant les coordonnées indiquées ci-dessus.
         </p>
     </section>
-    <section id="safeguarding">
-        <h3>Mesures de sauvegarde</h3>
+    <section id="safeguarding_fr">
+        <h3>Mesures conservatoires</h3>
         <p>
-            Xim accorde une grande importance à votre confidentialité et prend toutes les mesures et précautions raisonnables pour protéger et sécuriser vos données personnelles. Nous travaillons dur pour vous protéger, vous et vos informations, contre tout accès, modification, divulgation ou destruction non autorisés et avons mis en place plusieurs couches de mesures de sécurité,<b>notamment :  SSL, TLS, chiffrement, pseudonymisation, accès restreint, authentification informatique, pare-feu et antivirus/logiciels malveillants.</b>
+            Xim accorde une grande importance à votre confidentialité et prend toutes les mesures et
+            précautions raisonnables pour protéger et sécuriser vos données à caractère personnel. Nous travaillons dur pour vous protéger,
+            vous et vos informations, contre tout accès, modification, divulgation ou
+            destruction non autorisés et avons mis en place plusieurs couches de mesures de sécurité, <b>notamment : SSL,
+            TLS, chiffrement, pseudonymisation, accès restreint, authentification informatique,
+            pare-feu et antivirus/logiciels malveillants.</b>
         </p>
     </section>
-    <section id="transfers">
+    <section id="transfers_fr">
         <h3>Transferts en dehors du Royaume-Uni/de l’UE</h3>
         <p>
-            Les informations que nous recueillons auprès de vous peuvent être transférées, traitées et stockées dans des destinations en dehors du Royaume-Uni et de l’EEE. Lorsque nous transférons vos données vers des pays en dehors du Royaume-Uni et/ou de l’Espace économique européen (« EEE »), nous ne le ferons que si des mesures visant à protéger vos données et leur confidentialité ont été mises en place.
+            Les informations que nous recueillons auprès de vous peuvent être transférées, traitées et
+            stockées dans des destinations en dehors du Royaume-Uni et de l’EEE. Lorsque nous transférons vos données vers
+            des pays en dehors du Royaume-Uni et/ou de l’Espace économique européen (« EEE »), nous ne le ferons que si
+            des mesures visant à protéger vos données et leur confidentialité ont été mises
+            en place.
         </p>
         <p>
-            Chaque fois que nous transférons vos données personnelles hors de l’EEE et/ou du Royaume-Uni, nous veillons à ce qu’elles bénéficient d’un degré de protection similaire en veillant à ce qu’au moins l’une des garanties suivantes soit mise en œuvre:
+            Chaque fois que nous transférons vos données à caractère personnel hors de l’EEE et/ou du Royaume-Uni, nous
+            veillons à ce qu’elles bénéficient d’un degré de protection similaire en veillant à ce qu’au moins l’une
+            des garanties suivantes soit mise en œuvre :
         </p>
         <ul>
-            <li>nous ne transférerons vos données personnelles que vers des pays qui ont été considérés comme offrant un niveau adéquat de protection des données personnelles par la Commission européenne (dans le cas de transferts en dehors de l’EEE) ou le gouvernement britannique (dans le cas de transferts en dehors du Royaume-Uni) ; et/ou
+            <li>nous ne transférerons vos données à caractère personnel que vers des pays qui ont été considérés comme
+                offrant un niveau adéquat de protection des données à caractère personnel par la Commission
+                européenne (dans le cas de transferts en dehors de l’EEE) ou le gouvernement britannique (dans
+                le cas de transferts en dehors du Royaume-Uni) ; et/ou
             </li>
-            <li>lorsque nous faisons appel à certains prestataires de services, nous pouvons utiliser des contrats spécifiques approuvés par la Commission européenne (dans le cas de transferts en dehors de l’EEE) et/ou le gouvernement britannique (dans le cas de transferts en dehors du Royaume-Uni), dans les deux cas, qui confèrent aux données personnelles la même protection qu’au sein de l’EEE et/ou du Royaume-Uni, selon le cas. Pour obtenir davantage d’informations, veuillez nous contacter.
+            <li>lorsque nous faisons appel à certains prestataires de services, nous pouvons utiliser des contrats spécifiques approuvés
+                par la Commission européenne (dans le cas de transferts en dehors de l’EEE) et/ou
+                le gouvernement britannique (dans le cas de transferts en dehors du Royaume-Uni), dans les deux cas, qui
+                confèrent aux données à caractère personnel la même protection qu’au sein de l’EEE et/ou du Royaume-Uni,
+                selon le cas. Pour obtenir davantage d’informations, veuillez nous contacter.
             </li>
         </ul>
     </section>
-    <section id="legitimate">
+    <section id="legitimate_fr">
         <h3>Évaluation des intérêts légitimes</h3>
         <p>
-            Comme indiqué dans la section <a href="https://lifelight.ai/privacy-notice/#legal"><i>‘ Comment nous utilisons vos données personnelles (base légale et finalité du traitement)’</i></a> du présent avis de confidentialité, nous traitons occasionnellement vos informations personnelles sur la base légale des intérêts légitimes. Dans ce cas de figure, nous effectuons une évaluation approfondie des intérêts légitimes ('EL') pour nous assurer que nous avons évalué le rapport entre vos intérêts et tout risque qui vous est posé, et nos propres intérêts ; en veillant à ce que celui-ci soit proportionné et approprié.
+            Comme indiqué dans la section <a href="https://lifelight.ai/privacy-notice/#legal"><i>« Comment nous utilisons vos
+            données à caractère personnel (base légale et finalité du
+            traitement) »</i></a> du présent avis de confidentialité, nous traitons occasionnellement vos
+            informations personnelles
+            sur la base légale des intérêts légitimes. Dans ce cas de figure, nous
+            effectuons une évaluation approfondie des intérêts légitimes (« LIA ») pour nous assurer
+            que nous avons évalué le rapport entre vos intérêts et tout risque qui vous est posé, et nos propres
+            intérêts ; en veillant à ce que celui-ci soit proportionné et approprié.
         </p>
     </section>
-    <section id="long">
-        <h3>Pendant combien de temps conservons-nous vos données</h3>
+    <section id="long_fr">
+        <h3>Pendant combien de temps conservons-nous vos données ?</h3>
         <p>
-            Xim conserve uniquement les renseignements personnels aussi longtemps que nécessaire pour atteindre les objectifs pour lesquels nous les avons recueillis, y compris aux fins de satisfaire aux exigences légales, réglementaires, fiscales, comptables ou déclaratives, et nous avons mis en place des politiques strictes d’examen et de conservation pour respecter ces obligations. En vertu de la législation fiscale britannique, nous sommes tenus de conserver certaines données personnelles de base de nos clients pendant au moins 6 ans après qu’ils ont cessé d’être clients.  En tant que fabricant de l’Application Lifelight, nous sommes tenus de conserver certaines données personnelles des patients et des utilisateurs de l’Application pendant une période minimale de 10 ans.
+            Xim conserve uniquement les informations personnelles aussi longtemps que nécessaire pour atteindre les
+            objectifs pour lesquels nous les avons recueillis, y compris aux fins de satisfaire aux exigences
+            légales, réglementaires, fiscales, comptables ou déclaratives, et nous avons mis en place des politiques strictes d’examen
+            et de conservation pour respecter ces obligations. En vertu de la
+            législation fiscale britannique, nous sommes tenus de conserver certaines données à caractère personnel de base de nos clients pendant au moins
+            6 ans après qu’ils ont cessé d’être clients. En tant que fabricant de
+            l’Application Lifelight, nous sommes tenus de conserver certaines données à caractère personnel des patients
+            et des utilisateurs de l’Application pendant une période minimale de 10 ans.
         </p>
         <p>
-            Lorsque vous consentez à ce que nous utilisions vos coordonnées à des fins de marketing direct, nous conservons ces données jusqu’à ce que vous nous informiez du contraire et/ou retiriez votre consentement.
+            Lorsque vous consentez à ce que nous utilisions vos coordonnées à des fins de marketing direct, nous
+            conservons ces données jusqu’à ce que vous nous informiez du contraire et/ou retiriez votre consentement.
         </p>
     </section>
-    <section id="national">
-        <h3>National Data Opt-out – Personnes concernées au Royaume-Uni uniquement</h3>
+    <section id="national_fr">
+        <h3>National Data Opt-out (personnes concernées au Royaume-Uni uniquement)</h3>
         <p>
-            Au Royaume-Uni, le NHS, les autorités locales, les chercheurs universitaires et hospitaliers, les facultés de médecine et les sociétés pharmaceutiques à la recherche de nouveaux traitements peuvent utiliser vos informations confidentielles sur les patients pour la recherche et la planification.  Vous pouvez choisir si vos informations confidentielles en tant que patient <a
-                href="https://www.nhs.uk/your-nhs-data-matters/">is used for research and
-            planning</a> et vous pouvez modifier votre choix à tout moment.  Si vous ne souhaitez pas que vos informations confidentielles en tant patient soient utilisées à des fins de recherche et de planification, vous pouvez choisir de vous désinscrire en toute sécurité en ligne ou via un service téléphonique. Sinon, vous n’avez aucune démarche à entreprendre.
+            Au Royaume-Uni, le NHS, les autorités locales, les chercheurs universitaires et hospitaliers, les facultés de
+            médecine et les sociétés pharmaceutiques à la recherche de nouveaux traitements peuvent utiliser vos
+            informations confidentielles sur les patients pour la recherche et la planification. Vous pouvez choisir
+            si vos informations confidentielles en tant que patient <a href="https://www.nhs.uk/your-nhs-data-matters/">seront utilisées pour la recherche et
+            la planification</a> et vous pouvez modifier votre choix à tout moment. Si vous ne souhaitez pas que vos
+            informations confidentielles en tant patient soient utilisées à des fins de recherche et de planification, vous pouvez
+            choisir de vous désinscrire en toute sécurité en ligne ou via un service téléphonique. Sinon, vous
+            n’avez aucune démarche à entreprendre.
         </p>
     </section>
-    <section id="complaint">
+    <section id="complaint_fr">
         <h3>Déposer une plainte</h3>
         <p>
-            Xim traite vos informations personnelles uniquement en conformité avec le présent Avis de confidentialité et en conformité avec les lois applicables en matière de protection des données.
+            Xim traite vos informations personnelles uniquement en conformité avec le présent avis
+            de confidentialité et en conformité avec les lois applicables en matière de protection des données.
         </p>
         <p>
-            Si, toutefois, vous souhaitez déposer une plainte concernant le traitement de vos données personnelles ou si vous n’êtes pas satisfait de la manière dont nous avons traité vos informations, vous avez le droit de déposer une plainte auprès de votre autorité nationale de protection des données.
+            Si, toutefois, vous souhaitez déposer une plainte concernant le traitement de vos
+            données à caractère personnel ou si vous n’êtes pas satisfait(e) de la manière dont nous avons traité vos informations, vous
+            avez le droit de déposer une plainte auprès de votre autorité nationale de protection des données.
         </p>
         <p>
-            <b>Information Commissioners Office (ICO)</b> – Siège social de l’ICO: Wycliffe House,<br>
-            Water Lane, Wilmslow, Cheshire SK9 5AF<br>
-            Tel: 0303 123 1113 (tarif local) or 01625 545 745 si vous préférez utiliser un numéro de tarif national.<br>
-            Rendez-vous ici: <a href="https://ico.org.uk/make-a-complaint/">https://ico.org.uk/make-a-complaint</a>
+            <b>Information Commissioners Office (ICO)</b> – Siège social de l’ICO : Wycliffe House,<br>
+            Water Lane, Wilmslow, Cheshire SK9 5AF<br>
+            Tél : 0303 123 1113 (tarif local) ou 01625 545 745 si vous préférez utiliser un
+            numéro de tarif national.<br>
+            Visitez : <a href="https://ico.org.uk/make-a-complaint/">https://ico.org.uk/make-a-complaint</a>
         </p>
     </section>
 </main>
-</body>
-</html>
+
+</body></html>

--- a/termsandconditions/lifelightclassII-terms-and-conditions-fr.html
+++ b/termsandconditions/lifelightclassII-terms-and-conditions-fr.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<!-- saved from url=(0093)https://xim-lifelight.github.io/termsandconditions/lifelightclassII-terms-and-conditions.html -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-173128924-1');
+    </script>
+
+
+    <title>Conditions de licence Lifelight</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="ll-t&cs.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+<main class="centred">
+    <section> <!--cover & title-->
+        <h1>Conditions de licence Lifelight</h1>
+    </section>
+    <h3>VEUILLEZ LIRE ATTENTIVEMENT LES PRÉSENTES CONDITIONS DE LICENCE D’UTILISATION</h3>
+    <p>Lifelight peut être utilisé par les professionnels de la santé dans le cadre de leur activité professionnelle, pour la prestation de services de santé
+        et de soins aux patients ou par les patients eux-mêmes pour la surveillance de leur propre fréquence cardiaque/pouls, de leur pression artérielle et
+        de leur respiration.</p>
+    <p>Vous avez la responsabilité de vous assurer que toutes les personnes accédant à l’application Lifelight à partir de votre
+        appareil ont pris connaissance des présentes conditions et s’y conforment.</p>
+    <p>En cochant la case, vous acceptez les présentes conditions qui vous lieront au niveau contractuel.</p>
+    <p>Si vous n’acceptez pas les présentes conditions, ne cochez pas la case.</p>
+    <h3>QUI SOMMES-NOUS ET QU’IMPLIQUENT LES PRÉSENTES CONDITIONS ?</h3>
+    <p>Xim Limited (numéro d’entreprise 03699022) (<b>nous</b>/<b>notre</b>/<b>nos</b>/<b>Xim</b>)
+        vous autorise, que vous agissiez en tant que professionnel de la santé pour fournir
+        des services de santé et de soins aux patients (Professionnel de la santé) ou pour
+        un patient à vos propres fins <b>(Patient)</b>, à utiliser :</p>
+    <ul>
+        <li>le logiciel de l’application mobile Lifelight, les
+            données fournies avec le logiciel et toutes les mises à jour ou compléments à celui-ci tels
+            que proposés de temps à autre <b>(Application Lifelight)</b> ;
+        </li>
+        <li>la documentation électronique connexe, incluant par exemple
+            les Instructions d’utilisation et l’ensemble des informations ou suppléments fournis
+            de temps à autres <b>(Documentation)</b> ; et
+        </li>
+        <li>les services et contenus auxquels vous accédez via l’Application Lifelight
+            <b>(Solution SaaS Lifelight)</b>, y compris lorsque l’accès à l’Application Lifelight est fourni dans le cadre d’un autre produit,
+        </li>
+    </ul>
+    <p>(désignés ensemble sous le nom de <b>Lifelight</b>), dans le cadre des présentes conditions.</p>
+    <p>Lifelight® est une marque déposée par Xim Limited. Tous les droits non
+        expressément accordés par nous en vertu des présentes conditions sont réservés.</p>
+    <p>Notre adresse est University of Southampton Science Park, Venture
+        Road, Chilworth, Southampton, Hampshire, Angleterre, SO16 7NP. Notre numéro de TVA
+        est le 726893394.</p>
+    <p>Lifelight est un dispositif médical de classe IIa, approuvé en tant que logiciel de dispositif médical dans le cadre du règlement de l’UE relatifs aux dispositifs médicaux (règlement (UE) 2017/745).
+        En tant que logiciel de dispositif médical marqué CE, Lifelight est approuvé pour une distribution dans l’EEE, en Suisse, en Irlande du Nord et en Grande-Bretagne
+        sous le numéro de certificat MDR de l’UE G151039400003 et la référence de demande 2025032101413842 auprès du MHRA britannique (pour une distribution en Grande-Bretagne).</p>
+    <p>Notez que Xim n’interprète pas les résultats produits par
+        Lifelight. L’interprétation doit toujours être effectuée par un professionnel de la santé.</p>
+    <p>Vous pouvez contacter les importateurs et les représentants autorisés concernés par la juridiction dans
+        laquelle vous
+        êtes établi(e) en utilisant les coordonnées fournies dans l’Application Lifelight, telles que mises à jour
+        de temps à
+        autre. Si vous êtes établi(e) en Grande-Bretagne, veuillez contacter Xim en utilisant nos coordonnées
+        indiquées ci-dessus.</p>
+    <h3>VOTRE CONFIDENTIALITÉ</h3>
+    <p>Nous n’utilisons que les données à caractère personnel :</p>
+    <ul>
+        <li>qui vous permettent d’accéder à Lifelight ;</li>
+        <li>pour se conformer aux exigences réglementaires ;</li>
+        <li>que nous collectons par le biais de votre utilisation de Lifelight (il peut s’agir de vos données si
+            vous êtes un Patient ou de vos données et de celles de votre patient si vous êtes un
+            Professionnel de la santé) ; et
+        </li>
+        <li>que nous recevons du prestataire de soins que vous représentez
+            ou qui vous fournit des services de soins <b>(Prestataire
+                de soins)</b>, directement ou indirectement par le biais d’un intermédiaire fournissant
+            des services à votre Prestataire de soins,
+        </li>
+    </ul>
+    <p>selon les modalités énoncées dans notre <a href="https://lifelight.ai/privacy-notice/">Avis de confidentialité</a>,
+        disponible sur notre site Web.</p>
+    <p>Nous partagerons vos données à caractère personnel (en particulier, les résultats produits par Lifelight) avec
+        votre
+        Prestataire de soins, les intermédiaires fournissant des services à votre Prestataire de soins et
+        le prestataire
+        de services qui a mis Lifelight à votre disposition via leur application. Nous agirons en tant que
+        sous-traitant des données
+        lorsque nous partagerons vos données à caractère personnel avec les responsables du traitement des données susmentionnés.</p>
+    <p>En tant que fabricant de l’appareil, Xim est légalement tenu de stocker certaines données pendant une
+        période minimale
+        de 10 ans. Pour en savoir plus à ce sujet, veuillez consulter notre <a href="https://lifelight.ai/privacy-notice/">Avis de confidentialité</a>.</p>
+
+    <p>En outre, ces informations sont transmises :</p>
+    <ul>
+        <li>au Prestataire de soins ou à l’intermédiaire fournissant des services à votre Prestataire de soins,
+            qui sera responsable du stockage de ces informations dans le cadre des services de santé et
+            de soins aux patients qu’il fournit ;
+        </li>
+        <li>au fournisseur de services qui a mis Lifelight à votre disposition par le biais de son produit ; ou</li>
+        <li>à vous, via l’Appareil.</li>
+    </ul>
+
+    <p>Lorsque nous transmettons vos données à caractère personnel à votre Prestataire de soins, à des intermédiaires fournissant des services
+        à votre Prestataire de soins ou au prestataire de services qui a mis Lifelight à votre disposition via son
+        produit, nous agissons en tant que sous-traitant des données et les personnes susmentionnées agissent en tant que
+        responsable du traitement des données.</p>
+    <p>
+        Veuillez noter que les transmissions par Internet ne sont jamais entièrement privées ou sécurisées et que les informations
+        envoyées à l’aide de Lifelight sont susceptibles d’être lues ou interceptées par des tiers, même si vous êtes informé(e) qu’une
+        transmission particulière est chiffrée.
+    </p>
+    <h3>ACCÈS À LA CAMÉRA</h3>
+    <p>Lifelight doit pouvoir accéder à la caméra intégrée à l’Appareil (telle qu’il
+        est défini ci-dessous). Sans accès à la caméra, Lifelight ne sera pas en mesure de
+        surveiller vos paramètres vitaux.</p>
+    <p>Il vous sera demandé d’activer cette fonctionnalité lors de votre premier accès
+        à l’Application Lifelight. Vous pouvez désactiver cette fonctionnalité à tout moment, mais
+        si vous le faites, vous ne pourrez pas utiliser Lifelight aux fins prévues.</p>
+    <h3>CONFIGURATION REQUISE DU SYSTÈME D’EXPLOITATION</h3>
+    <p>Lifelight est conçue pour fonctionner sur n’importe quel smartphone ou tablette
+        disposant d’une caméra intégrée avec des spécifications minimales de
+        5 mégapixels, capable de produire des vidéos de qualité HD d’une résolution de 1280 x 720 pixels
+        à 30 images par seconde <b>(Appareil)</b>.</p>
+    <h3>ASSISTANCE LIFELIGHT</h3>
+    <p><b>Assistance.</b> Si vous souhaitez en savoir plus sur Lifelight ou si vous rencontrez
+        des problèmes dans l’utilisation de Lifelight, vous pouvez consulter nos ressources d’assistance
+        incluses dans la Documentation de l’Application Lifelight.</p>
+    <p><b>Nous contacter (y compris en cas de plainte).</b> Si vous jugez que Lifelight est
+        défectueux ou mal décrit, ou si vous souhaitez nous contacter pour toute autre raison, veuillez
+        envoyer un e-mail à notre équipe de service client, à l’adresse <a href="mailto:support@lifelight.ai">support@lifelight.ai</a>. Si vous
+        êtes établi(e) dans l’EEE, en Suisse ou en Irlande du Nord, vous pouvez également contacter les représentants
+        autorisés et/ou l’importateur concernés.
+    </p>
+    <p><b>Comment communiquerons-nous avec vous ?</b> Si nous vous répondons, nous vous enverrons une réponse par e-mail, en utilisant
+        l’adresse e-mail que vous nous avez fournie si vous utilisez une version complète et enregistrée de
+        l’Application Lifelight.</p>
+    <h3>COMMENT POUVEZ-VOUS UTILISER LIFELIGHT, Y COMPRIS LE NOMBRE D’APPAREILS
+        SUR LESQUELS VOUS POUVEZ L’UTILISER ?</h3>
+    <p>En échange de votre engagement à respecter les présentes conditions :</p>
+    <ul>
+        <li>vous pouvez télécharger une copie de l’Application Lifelight (que ce soit en tant qu’application autonome
+            ou dans le cadre d’un autre produit dans lequel Lifelight a été incorporé) sur un seul Appareilç
+            (à condition qu’il réponde aux exigences du système d’exploitation) et afficher, utiliser et afficher Lifelight sur
+            ledit appareil pour votre usage personnel uniquement si vous êtes un Patient ou pour fournir des soins aux patients si vous êtes
+            un Professionnel de la santé ;
+        </li>
+        <li>vous pouvez utiliser toute Documentation fournie dans le cadre de votre utilisation autorisée de
+            Lifelight ;
+        </li>
+        <li>vous pouvez faire jusqu’à une copie de l’Application Lifelight et de la
+            Documentation, à des fins de sauvegarde uniquement ; et
+        </li>
+        <li>vous pouvez recevoir et utiliser tout code logiciel supplémentaire gratuit, ou
+            mise à jour de l’Application Lifelight intégrant des mises à jour, des révisions,
+            des « patches » et des correctifs d’erreurs que nous sommes susceptibles de vous fournir.
+        </li>
+    </ul>
+    <p>VOUS DEVEZ ÊTRE ÂGÉ(E) DE 18 ANS OU PLUS POUR ACCEPTER LES PRÉSENTES CONDITIONS ET UTILISER
+        LIFELIGHT</p>
+    <p>VOUS NE POUVEZ PAS TRANSFÉRER LIFELIGHT À UNE AUTRE PERSONNE</p>
+    <p>Nous vous accordons le droit d’utiliser Lifelight à titre personnel, comme indiqué
+        ci-dessus. Vous ne pouvez pas transférer Lifelight à une autre personne.</p>
+    <p>Si vous êtes un Professionnel de santé et que vous quittez un Prestataire
+        de soins (que vous soyez ou non propriétaire de l’Appareil que vous utilisez), vous
+        devez retirer l’Application Lifelight de l’Appareil.</p>
+    <h3>MODIFICATIONS DES PRÉSENTES CONDITIONS</h3>
+    <p>Il se peut que nous soyons tenus de modifier les présentes conditions afin de refléter des évolutions dans la législation
+        ou dans les bonnes pratiques, ou pour prendre en compte les fonctionnalités supplémentaires que nous présentons.</p>
+    <p>Ces modifications vous seront notifiées lors de votre prochain accès à
+        l’Application Lifelight. Si vous n’acceptez pas les modifications qui vous sont notifiées, vous ne serez pas
+        autorisé(e) à poursuivre votre utilisation de Lifelight.</p>
+    <h3>D’AUTRES CONDITIONS PEUVENT ÉGALEMENT S’APPLIQUER</h3>
+    <p>Votre utilisation de Lifelight peut également être contrôlée
+        par :</p>
+    <ul>
+        <li>les règles et politiques de la boutique d’applications à partir de laquelle vous avez
+            téléchargé Lifelight® ;
+        </li>
+        <li>si Lifelight® est intégré à un autre produit, le fournisseur des
+            règles et politiques dudit produit ; et
+        </li>
+        <li>les conditions imposées par votre Prestataire de soins ou par un intermédiaire
+            fournissant des services à votre Prestataire de soins, si vous êtes un Patient, ou, si
+            vous êtes un Professionnel de santé, le Prestataire de soins que vous
+            représentez.
+        </li>
+    </ul>
+    <h3>MISES À JOUR DE L’APPLICATION LIFELIGHT ET ÉVOLUTIONS DE LA
+        SOLUTION SAAS LIFELIGHT</h3>
+    <p>De temps à autres, nous sommes susceptibles de mettre à jour automatiquement l’Application Lifelight
+        et d’apporter des modifications à la Solution SaaS Lifelight afin d’améliorer
+        la performance, la fonctionnalité, de refléter les changements dans le fonctionnement
+        du système, ou de résoudre des problèmes de sécurité. Nous pouvons également vous demander de
+        mettre à jour l’Application Lifelight pour l’une de ces raisons.</p>
+    <p>Si vous choisissez de ne pas installer nos mises à jour, vous ne pourrez peut-être pas
+        continuer à utiliser l’Application Lifelight et la Solution SaaS Lifelight.
+    </p>
+    <p>L’Application Lifelight fonctionnera toujours avec la version en cours
+        du système d’exploitation (telle que mise à jour de temps à autre) et correspondra à
+        la description qui vous a été fournie dans les instructions d’utilisation associées.
+    </p>
+    <h3>SI UNE AUTRE PERSONNE EST PROPRIÉTAIRE DE L’APPAREIL QUE VOUS UTILISEZ</h3>
+    <p>Si vous téléchargez l’Application Lifelight sur un Appareil dont vous n’êtes pas
+        propriétaire, vous devez disposer de l’autorisation du propriétaire. Vous serez
+        responsable du respect des présentes conditions, que vous soyez propriétaire ou non
+        de l’Appareil.</p>
+    <h3>NOUS NE SOMMES PAS RESPONSABLES DES AUTRES SITES WEB AUXQUELS
+        VOUS ACCÉDEZ</h3>
+    <p>Lifelight peut contenir des liens vers d’autres sites Web indépendants qui ne sont
+        pas fournis par nous-mêmes. Ces sites indépendants ne sont pas sous notre contrôle,
+        nous ne sommes pas responsables et n’avons pas vérifié ou approuvé
+        leur contenu ou leurs politiques de confidentialité (le cas échéant).</p>
+    <p>Vous devrez utiliser votre propre jugement quant à l’utilisation
+        de ces sites indépendants, y compris quant à l’opportunité d’acheter des
+        produits ou services qui y sont proposés, ou de suivre les conseils ou les recommandations
+        qui y sont donnés.</p>
+    <h3>RESTRICTIONS DE LICENCE</h3>
+    <p>Vous acceptez de :</p>
+    <ul>
+        <li>ne pas louer, sous-licencier, prêter, fournir ou rendre Lifelight disponible
+            de toute autre manière, sous quelque forme que ce soit, en tout ou en partie, à toute personne sans
+            consentement écrit préalable de notre part ;
+        </li>
+        <li>ne pas copier Lifelight (ou une partie de Lifelight), sauf dans le cadre
+            d’une utilisation normale de Lifelight ou lorsque cela est nécessaire à des fins de sauvegarde ou
+            de sécurité opérationnelle ;
+        </li>
+        <li>ne pas traduire, fusionner, adapter, varier, altérer ou modifier, l’ensemble ou
+            toute partie de Lifelight, ni permettre à Lifelight ou à toute partie de Lifelight d’être combiné
+            avec, ou de s’incorporer à, tout autre programme, sauf dans les contextes où cela est nécessaire
+            pour utiliser Lifelight sur les appareils, comme autorisé dans les présentes conditions ;
+        </li>
+        <li>ne pas désassembler, décompiler, rétro-concevoir ou créer
+            des travaux dérivés fondés sur tout ou partie de Lifelight, ni tenter de
+            vous livrer à ces activités, sauf dans la mesure où (en vertu des articles 50B
+            et 296A du Copyright, Designs and Patents Act 1988) de telles actions
+            ne pourraient être interdites, étant nécessaires à la décompilation
+            de l’Application Lifelight afin d’obtenir les informations nécessaires à la création d’un
+            programme indépendant pouvant être utilisé avec l’Application Lifelight
+            ou avec un autre programme (Objectif autorisé), et à condition que
+            les informations que vous avez obtenues au cours de ces activités :
+            <ul>
+                <li>ne soient pas divulguées ou communiquées, sans notre consentement écrit préalable,
+                    à un tiers à qui il ne serait pas réellement nécessaire de les divulguer
+                    ou de les communiquer pour atteindre l’Objectif autorisé ; et
+                </li>
+                <li>ne soient pas utilisées pour la création d’un logiciel substantiellement
+                    similaire dans son expression à l’Application Lifelight ;
+                </li>
+                <li>soient conservées en lieu sûr ; et</li>
+                <li>soient utilisées uniquement en vue de l’Objectif autorisé ;</li>
+            </ul>
+        </li>
+        <li>se conformer à toutes les lois applicables en matière de contrôle technologique ou d’exportation et
+            les réglementations s’appliquant à la technologie utilisée ou prise en charge par
+            Lifelight.
+        </li>
+    </ul>
+    <h3>RESTRICTIONS D’UTILISATION ACCEPTABLES</h3>
+    <p>Vous avez l’obligation de :</p>
+    <ul>
+        <li>ne pas utiliser Lifelight de manière illégale, dans tout objectif
+            illégal, ou d’une manière incompatible avec les présentes conditions, ou agir
+            frauduleusement ou malicieusement, par exemple en piratant ou en insérant
+            du code malveillant, tel qu’un virus ou des données malveillantes, au sein de Lifelight ou
+            de tout
+            système d’exploitation ;
+        </li>
+        <li>ne pas porter atteinte à nos droits de propriété intellectuelle ou à ceux d’un tiers
+            en lien avec votre utilisation de Lifelight ;
+        </li>
+        <li>ne pas transmettre d’informations diffamatoires, offensantes ou
+            autrement répréhensibles concernant votre utilisation de Lifelight ;
+        </li>
+        <li>ne pas utiliser Lifelight d’une manière qui pourrait endommager, désactiver,
+            surcharger, altérer ou compromettre nos systèmes ou leur sécurité, ou interférer
+            avec d’autres utilisateurs ; et
+        </li>
+        <li>ne pas collecter ou récolter d’informations ou de données auprès de Lifelight ou
+            de nos systèmes, ou tenter de déchiffrer toute transmission vers ou à partir
+            de serveurs exécutant Lifelight.
+        </li>
+    </ul>
+    <h3>DROITS DE PROPRIÉTÉ INTELLECTUELLE</h3>
+    <p>Vous reconnaissez que tous les droits de propriété intellectuelle de Lifelight
+        dans le monde entier nous appartiennent (ou appartiennent à nos titulaires de licences), que les droits sur Lifelight
+        vous sont concédés sous licence (non vendus), et que vous n’avez aucun droit de propriété intellectuelle
+        sur Lifelight autres que le droit d’utiliser Lifelight en confirmité
+        avec les présentes conditions.</p>
+    <h3>NOTRE RESPONSABILITÉ EN CAS DE PERTE OU DE DOMMAGE SUBI PAR VOUS –
+        LA PRÉSENTE CLAUSE NE S’APPLIQUE QU’AUX PATIENTS.</h3>
+    <p>SI VOUS ÊTES UN PROFESSIONNEL DE LA SANTÉ, NOTRE RESPONSABILITÉ ENVERS VOUS EST COUVERTE PAR
+        L’ACCORD ÉTABLI ENTRE LE PRESTATAIRE DE SOINS DE SANTÉ ET NOUS, DIRECTEMENT, OU
+        AVEC UN INTERMÉDIAIRE FOURNISSANT DES SERVICES À VOTRE PRESTATAIRE DE SOINS DE SANTÉ.</p>
+    <p><b>Nous sommes responsables envers vous des pertes et dommages prévisibles causés
+        par nous.</b> Dans le cas où nous ne respecterions pas les présentes conditions, nous serions tenus responsables des pertes ou
+        dommages que vous subiriez et qui seraient le résultat prévisible de notre violation desdites conditions
+        ou de notre manquement à faire preuve d’un soin et d’une compétence raisonnables. Nous ne saurions, en revanche, être tenus responsables
+        de toute perte ou tout dommage qui ne serait pas considéré comme prévisible. La perte ou le dommage est
+        prévisible s’il est évident qu’il se produira ou si, au moment de l’établissement
+        de la présente licence, vous et nous savions qu’il pouvait se produire.</p>
+    <p><b>Nous n’excluons ni ne limitons en aucune manière notre responsabilité envers vous
+        lorsqu’il serait illégal de le faire.</b> Cela inclut la responsabilité en cas de décès ou de blessures
+        causés par notre négligence ou celle de nos employés,
+        agents ou sous-traitants, ou en cas de fraude ou de fausse
+        déclaration.</p>
+    <p><b>Lorsque nous sommes responsables des dommages sur vos biens.</b> Si le contenu numérique
+        défectueux que nous avons fourni endommage un appareil ou
+        un contenu numérique vous appartenant, nous réparerons le dommage
+        ou vous verserons une indemnité. Cependant, nous ne serons pas tenus responsables des dommages que vous auriez
+        pu éviter en suivant nos conseils à l’occasion d’une mise à jour proposée gratuitement,
+        ou pour les dommages causés par vous après n’avoir pas suivi correctement
+        les instructions d’installation ou ne pas disposer de la configuration minimale
+        du système que nous recommandons.</p>
+    <p><b>Limites de Lifelight.</b> Lorsqu’il est utilisé correctement, Lifelight vous permet de
+        prendre des mesures précises des paramètres vitaux, conformément aux instructions d’utilisation. Lifelight
+        n’interprète pas les résultats de vos lectures de paramètres vitaux. L’interprétation doit toujours
+        être effectuée par un professionnel de la santé. Vous devez obtenir l’avis d’un professionnel
+        ou d’un spécialiste avant de prendre, ou de vous abstenir de prendre, des mesures sur
+        la base des informations obtenues auprès de Lifelight. Bien que nous nous efforcions
+        de mettre à jour les informations fournies par Lifelight, nous ne déclarons
+        ni ne garantissons, ni expressément ni implicitement, que ces informations
+        sont exactes, complètes ou à jour.</p>
+    <p><b>Vérifiez que Lifelight est adapté à vos besoins.</b>Vous reconnaissez que Lifelight n’a pas été
+        développé pour répondre à vos besoins individuels, et qu’il est donc de votre
+        responsabilité de vous assurer
+        que les possibilités et fonctions de Lifelight, telles que décrites dans la Documentation, répondent à vos
+        exigences.</p>
+    <p>Nous ne sommes pas responsables des événements indépendants de notre contrôle. Si notre capacité à proposer Lifelight ou
+        à vous assister dans l’utilisation de Lifelight est retardée par un événement indépendant de notre contrôle, votre Prestataire
+        de soins ou l’intermédiaire fournissant des services à votre Prestataire de soins vous en informera, et nous prendrons
+        des mesures pour minimiser les effets de ce retard. Nous ne serons pas responsables des retards causés par
+        l’événement en question. Vous pouvez toujours mettre fin à votre contrat avec nous si vous ne souhaitez plus utiliser Lifelight.</p>
+    <h3>EN CAS D’URGENCE MÉDICALE, VOUS DEVEZ TOUJOURS APPELER DIRECTEMENT
+        VOTRE PRESTATAIRE DE SOINS DE SANTÉ OU UTILISER LES
+        LIGNES D’ASSISTANCE DE VOTRE SYSTÈME DE SOINS DE SANTÉ NATIONAL.</h3>
+    <br>
+    <h3>NOUS POUVONS METTRE FIN À VOS DROITS D’UTILISER LIFELIGHT SI VOUS VIOLEZ
+        LES PRÉSENTES CONDITIONS</h3>
+    <p>Si nous considérons qu’une violation des présentes conditions s’est produite, nous pouvons
+        prendre les mesures que nous jugerons appropriées.</p>
+    <p>Si vous avez commis une infraction sérieuse aux présentes conditions (si vous êtes un
+        Professionnel de la santé, ces actions incluent également la violation de l’accord entre le Prestataire de soins
+        et nous, ou avec les intermédiaires qui proposent des services au Prestataire de soins)
+        nous pouvons envisager toutes ou partie
+        des mesures suivantes :</p>
+    <ul>
+        <li>le retrait immédiat, temporaire ou permanent de votre droit d’utilisation de
+            Lifelight ;
+        </li>
+        <li>la suppression immédiate, temporaire ou permanente de toute donnée
+            chargée par vous sur Lifelight ;
+        </li>
+        <li>l’émission d’un avertissement à votre intention ou à celle du Prestataire de soins ou d’un
+            intermédiaire fournissant des services à votre Prestataire de soins (si vous êtes un
+            Professionnel de la santé) ;
+        </li>
+        <li>une action en justice contre vous ou contre le Prestataire de soins ou un
+            intermédiaire fournissant des services à votre Prestataire de soins (si vous êtes un
+            Professionnel de la santé) ;
+        </li>
+        <li>la divulgation des informations aux autorités chargées de l’application de la loi
+            dans la mesure où nous la jugeons raisonnablement nécessaire ou requise par la loi.
+        </li>
+    </ul>
+    <p>Les mesures que nous sommes susceptibles de prendre ne sont pas limitées à celles décrites
+        ci-dessus et nous pouvons prendre toute autre mesure que nous jugerons appropriée.</p>
+    <p>Si nous mettons fin à vos droits d’utilisation de Lifelight :</p>
+    <ul>
+        <li>vous devez cesser toutes les activités autorisées par les présentes conditions, y compris
+            votre utilisation de Lifelight.
+        </li>
+        <li>vous devez supprimer ou retirer l’Application Lifelight de
+            l’Appareil en votre possession, détruire immédiatement toutes les copies
+            de l’Application Lifelight en votre possession, et nous confirmer que vous
+            l’avez fait ;
+        </li>
+    </ul>
+    <h3>TRANSFERT DE LA PRÉSENTE LICENCE À UNE AUTRE PERSONNE</h3>
+    <p>Nous pouvons transférer, céder, facturer, sous-traiter ou traiter de toute autre
+        façon tout ou partie de nos droits et obligations, en vertu des présentes
+        conditions.</p>
+    <p>En revanche, vous ne pouvez pas transférer vos droits ou vos obligations
+        en vertu des présentes conditions à un tiers sans un accord écrit de notre part.</p>
+    <h3>DROITS DES TIERS</h3>
+    <p>Sauf droits spécifiques à l’organisation que vous représentez, les présentes conditions
+        ne donnent lieu à aucun droit au titre du Contracts (Rights of Third Parties) Act 1999
+        por faire respecter ses conditions.</p>
+    <h3>SI L’UNE DES DISPOSITIONS DU PRÉSENT CONTRAT EST JUGÉE ILLÉGALE PAR UN TRIBUNAL,
+        LE RESTE DU CONTRAT DEMEURE EN VIGUEUR</h3>
+    <p>Chacun des paragraphes des présentes conditions est pris en compte séparément. Si un ou une autorité
+        compétente décide que l’un de ceux-ci est illégal, les autres paragraphes demeureront
+        en vigueur.</p>
+    <h3>MÊME SI NOUS RETARDONS L’EXÉCUTION DES PRÉSENTES CONDITIONS, NOUS POUVONS TOUJOURS
+        LES APPLIQUER PLUS TARD</h3>
+    <p>Même si nous tardons à exécuter les présentes conditions, nous pouvons toujours les appliquer
+        plus tard. Si nous n’insistons pas immédiatement pour que vous fassiez ce que vous êtes tenu
+        de faire en vertu des présentes conditions de licence, ou si nous tardons à prendre des mesures
+        à votre encontre après une rupture des présentes conditions de licence, cela ne signifie pas pour autant que vous soyez dispensé
+        de remplir vos obligations, et cela ne nous empêchera pas de prendre des mesures contre vous
+        à une date ultérieure.</p>
+    <h3>QUELLES LOIS S’APPLIQUENT AUX PRÉSENTES CONDITIONS ET QUELLE EST LA JURIDICTION COMPÉTENTE ?</h3>
+    <p>Les présentes conditions, leur objet et leur formation (ainsi que tout litige ou réclamation non-contractuel) sont
+        régis par le droit anglais et soumis à la compétence exclusive des tribunaux d’Angleterre et du Pays de Galles.
+        Si vous n’êtes pas basé en Angleterre et au Pays de Galles, vous pouvez engager des poursuites judiciaires à l’égard de Lifelight dans
+        le pays où vous vous trouvez.</p>
+    <p><strong>En cochant la case, vous acceptez les présentes conditions qui vous lieront au niveau contractuel.</strong></p>
+    <p><strong>Si vous n’acceptez pas les présentes conditions, ne cochez pas la case.</strong></p>
+</main>
+
+</body></html>

--- a/termsandconditions/lltry-terms-and-conditions-fr.html
+++ b/termsandconditions/lltry-terms-and-conditions-fr.html
@@ -1,0 +1,297 @@
+<!DOCTYPE html>
+<!-- saved from url=(0082)https://xim-lifelight.github.io/termsandconditions/lltry-terms-and-conditions.html -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script type="text/javascript" async="" src="./Lifelight License Terms_files/analytics.js"></script><script type="text/javascript" async="" src="./Lifelight License Terms_files/js"></script><script async="" src="./Lifelight License Terms_files/js(1)"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+
+        gtag('config', 'UA-173128924-1');
+    </script>
+
+
+    <title>Conditions de licence Lifelight</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="ll-t&cs.css" rel="stylesheet" type="text/css">
+</head>
+
+<body>
+<main class="centred">
+    <section> <!--cover & title-->
+        <h1>Conditions de licence de l’Application de démonstration Lifelight LLTry</h1>
+    </section>
+    <h3>VEUILLEZ LIRE ATTENTIVEMENT LES PRÉSENTES CONDITIONS DE LICENCE D’UTILISATION</h3>
+    <p>LLTry est une version de démonstration de la technologie Lifelight, mise à disposition par Xim Limited pour permettre aux utilisateurs d’exploiter les capacités de notre technologie de mesure des paramètres vitaux sans contact. Il ne s’agit <b>pas d’un dispositif médical</b> et il ne doit <b>pas</b> être utilisé
+        pour le diagnostic, la surveillance ou le traitement. LLTry est fourni à des fins d’illustration et d’évaluation uniquement, et ne fournit <b>pas</b> de résultats de qualité médicale.</p>
+    <p>Vous avez la responsabilité de vous assurer que toutes les personnes accédant à la présente application à partir de votre
+        appareil ont connaissance des présentes conditions et s’y conforment.</p>
+    <p>En cochant la case, vous acceptez les présentes conditions qui vous lieront au niveau contractuel.</p>
+    <p>Si vous n’acceptez pas les présentes conditions, ne cochez pas la case.</p>
+    <h3>QUI SOMMES-NOUS ET QU’IMPLIQUENT LES PRÉSENTES CONDITIONS ?</h3>
+    <p>Xim Limited (numéro d’entreprise 03699022) (<b>nous</b>/<b>notre</b>/<b>nos</b>/<b>Xim</b>)
+        vous autorise, que vous agissiez en tant que professionnel de la santé pour fournir
+        des services de santé et de soins aux patients (Professionnel de la santé) ou pour
+        un patient à vos propres fins <b>(Patient)</b>, à utiliser :</p>
+    <ul>
+        <li>le logiciel de l’application mobile LLTry, les données fournies
+            avec le logiciel et toutes les mises à jour ou compléments à celui-ci tels
+            que proposés de temps à autre <b>(Application Lifelight)</b> ;
+        </li>
+        <li>la documentation électronique correspondante <b>(Documentation)</b> ; et
+        </li>
+        <li>les services et contenus auxquels vous accédez via l’Application LLTry
+            (désignés ensemble sous le nom de <b>LLTry</b>), dans le cadre des présentes conditions.
+        </li>
+    </ul>
+    <p>Lifelight® est une marque déposée par Xim Limited. Tous les droits non
+        expressément accordés par nous en vertu des présentes conditions sont réservés.</p>
+    <p>Notre adresse est University of Southampton Science Park, Venture
+        Road, Chilworth, Southampton, Hampshire, Angleterre, SO16 7NP. Notre numéro de TVA
+        est le 726893394.</p>
+    <p>LLTry est un <b>outil de démonstration</b> destiné à présenter le potentiel de la technologie Lifelight.
+        <b>Il ne s’agit pas d’un dispositif médical</b> et il <b>ne doit pas être utilisé
+            pour le diagnostic, la surveillance ou le traitement.</b>
+    </p>
+    <h3>VOTRE CONFIDENTIALITÉ</h3>
+    <p>Nous utilisons vos données à caractère personnel pour :</p>
+    <ul>
+        <li>vous donner accès à LLTry ;</li>
+        <li>suivre les performances de la démonstration et analyser son utilisation.</li>
+    </ul>
+    <p>Pour plus d’informations, veuillez consulter notre <a href="https://lifelight.ai/privacy-notice/">Avis de confidentialité</a>.<br>
+        LLTry n’est pas destiné à traiter ou à stocker des informations de santé personnelles à des fins cliniques.</p>
+    <h3>ACCÈS À LA CAMÉRA</h3>
+    <p>LLTry doit pouvoir accéder à la caméra intégrée à l’Appareil (telle qu’il
+        est défini ci-dessous). Sans accès à la caméra, Lifelight ne sera pas en mesure de
+        fournir des estimations de paramètres vitaux.</p>
+    <p>Il vous sera demandé d’activer cette fonctionnalité lors de votre premier accès
+        à l’Application Lifelight. Vous pouvez modifier les autorisations d’accès à la caméra à tout moment dans les paramètres de votre appareil.</p>
+    <h3>CONFIGURATION REQUISE DU SYSTÈME D’EXPLOITATION</h3>
+    <p>Lifelight est conçue pour fonctionner sur n’importe quel smartphone ou tablette
+        disposant d’une caméra intégrée avec des spécifications minimales de
+        5 mégapixels, capable de produire des vidéos de qualité HD d’une résolution de 1280 x 720 pixels
+        à 30 images par seconde <b>(Appareil)</b>.</p>
+    <h3>ASSISTANCE LLTry</h3>
+    <p>L’assistance est disponible via l’aide intégrée à l’application ou en contactant : <a href="mailto:support@lifelight.ai">support@lifelight.ai</a></p>
+    <p><b>Comment communiquerons-nous avec vous ?</b> Si nous vous répondons, nous le ferons par e-mail, en utilisant l’adresse e-mail
+        que vous nous avez fournie.</p>
+    <h3>COMMENT POUVEZ-VOUS UTILISER LLTry ?</h3>
+    <p>En échange de votre engagement à respecter les présentes conditions :</p>
+    <ul>
+        <li>Vous pouvez installer LLTry sur un appareil compatible, à des fins de démonstration personnelle
+            uniquement ;
+        </li>
+        <li>Vous pouvez utiliser la documentation fournie pour vous aider à utiliser LLTry ;
+        </li>
+        <li>Vous pouvez recevoir et utiliser les mises à jour ou correctifs gratuits que nous fournissons.
+        </li>
+    </ul>
+    <p>Vous devez être âgé de 18 ans ou plus pour utiliser LLTry.</p>
+    <p>Vous ne pouvez pas transférer LLTry à une autre personne sans notre autorisation écrite.</p>
+    <h3>MODIFICATIONS DES PRÉSENTES CONDITIONS</h3>
+    <p>Nous pouvons mettre à jour les présentes conditions pour refléter les changements de la loi, les améliorations apportées à LLTry ou les commentaires.
+        Nous vous informerons de tout changement. Si vous n’acceptez pas les conditions mises à jour,
+        vous devez cesser d’utiliser LLTry.</p>
+    <h3>D’AUTRES CONDITIONS PEUVENT ÉGALEMENT S’APPLIQUER</h3>
+    <p>Votre utilisation de Lifelight peut également être contrôlée
+        par :</p>
+    <ul>
+        <li>les règles et politiques de la boutique d’applications à partir de laquelle vous avez
+            téléchargé LLTry
+        </li>
+    </ul>
+    <h3>MISES À JOUR DE LLTry</h3>
+    <br>
+    <h3>AUTRES CONDITIONS POUVANT S’APPLIQUER</h3>
+    <p>Votre utilisation de LLTry peut également être régie par :</p>
+    <ul>
+        <li>les règles et politiques de la boutique d’applications à partir de laquelle vous avez
+            téléchargé LLTry.</li>
+    </ul>
+    <h3>MISES À JOUR DE LLTRY</h3>
+    <p>Nous pouvons mettre à jour automatiquement LLTry pour améliorer ses performances, sa sécurité ou ses fonctionnalités.
+        Si vous choisissez de ne pas installer les mises à jour, LLTry pourrait ne plus fonctionner.</p>
+    <h3>SI UNE AUTRE PERSONNE EST PROPRIÉTAIRE DE L’APPAREIL QUE VOUS UTILISEZ</h3>
+    <p>Si vous installez LLTry sur un appareil dont vous n’êtes pas propriétaire,
+        vous devez disposer de l’autorisation nécessaire. Vous êtes
+        responsable du respect des présentes conditions.</p>
+    <h3>NOUS NE SOMMES PAS RESPONSABLES DES AUTRES SITES INTERNET AUXQUELS
+        VOUS ACCÉDEZ</h3>
+    <p>Lifelight peut contenir des liens vers d’autres sites internet indépendants qui ne sont
+        pas fournis par nous-mêmes. Ces sites indépendants ne sont pas sous notre contrôle,
+        nous ne sommes pas responsables et n’avons pas vérifié ou approuvé
+        leur contenu ou leurs politiques de confidentialité (le cas échéant).</p>
+    <p>Vous devrez utiliser votre propre jugement quant à l’utilisation
+        de ces sites indépendants, y compris quant à l’opportunité d’acheter des
+        produits ou services qui y sont proposés, ou de suivre les conseils ou les recommandations
+        qui y sont donnés.</p>
+    <h3>RESTRICTIONS DE LICENCE</h3>
+    <p>Vous acceptez de :</p>
+    <ul>
+        <li>ne pas louer, sous-licencier, prêter, fournir ou rendre LLTry disponible
+            de toute autre manière, sous quelque forme que ce soit, en tout ou en partie, à toute personne sans
+            consentement écrit préalable de notre part ;
+        </li>
+        <li>ne pas copier LLTry (ou une partie de LLTry), sauf dans le cadre
+            d’une utilisation normale de LLTry ou lorsque cela est nécessaire à des fins de sauvegarde ou
+            de sécurité opérationnelle ;
+        </li>
+        <li>ne pas traduire, fusionner, adapter, varier, altérer ou modifier, l’ensemble ou
+            toute partie de LLTry, ni permettre à LLTry ou à toute partie de LLTry d’être combiné
+            avec, ou de s’incorporer à, tout autre programme, sauf dans les contextes où cela est nécessaire
+            pour utiliser LLTry sur les appareils, comme autorisé dans les présentes conditions ;
+        </li>
+        <li>ne pas désassembler, décompiler, rétro-concevoir ou créer
+            des travaux dérivés fondés sur tout ou partie de LLTry, ni tenter de
+            vous livrer à ces activités, sauf dans la mesure où (en vertu des articles 50B
+            et 296A du Copyright, Designs and Patents Act 1988) de telles actions
+            ne pourraient être interdites, étant nécessaires à la décompilation
+            de l’Application afin d’obtenir les informations nécessaires à la création d’un
+            programme indépendant pouvant être utilisé avec l’Application
+            ou avec un autre programme (Objectif autorisé), et à condition que
+            les informations que vous avez obtenues au cours de ces activités :
+            <ul>
+                <li>ne soient pas divulguées ou communiquées, sans notre consentement écrit préalable,
+                    à un tiers à qui il ne serait pas réellement nécessaire de les divulguer
+                    ou de les communiquer pour atteindre l’Objectif autorisé ; et
+                </li>
+                <li>ne soient pas utilisées pour la création d’un logiciel substantiellement
+                    similaire dans son expression à l’Application ;
+                </li>
+                <li>soient conservées en lieu sûr ; et</li>
+                <li>soient utilisées uniquement en vue de l’Objectif autorisé ;</li>
+            </ul>
+        </li>
+        <li>se conformer à toutes les lois applicables en matière de contrôle technologique ou d’exportation et
+            les réglementations s’appliquant à la technologie utilisée ou prise en charge par
+            LLTry.
+        </li>
+    </ul>
+    <h3>RESTRICTIONS D’UTILISATION ACCEPTABLES</h3>
+    <p>Vous avez l’obligation de :</p>
+    <ul>
+        <li>ne pas utiliser LLTry de manière illégale, dans tout objectif
+            illégal, ou d’une manière incompatible avec les présentes conditions, ou agir
+            frauduleusement ou malicieusement, par exemple, en piratant ou en insérant
+            du code malveillant, tel qu’un virus ou des données malveillantes, au sein de LLTry ou de tout
+            système d’exploitation ;
+        </li>
+        <li>ne pas porter atteinte à nos droits de propriété intellectuelle ou à ceux d’un tiers
+            en lien avec votre utilisation de LLTry ;
+        </li>
+        <li>ne pas transmettre d’informations diffamatoires, offensantes ou
+            autrement répréhensibles concernant votre utilisation de LLTry ;
+        </li>
+        <li>ne pas utiliser LLTry d’une manière qui pourrait endommager, désactiver,
+            surcharger, altérer ou compromettre nos systèmes ou leur sécurité, ou interférer
+            avec d’autres utilisateurs ; et
+        </li>
+        <li>ne pas collecter ou récolter d’informations ou de données auprès de LLTry ou
+            de nos systèmes, ou tenter de déchiffrer toute transmission vers ou à partir
+            de serveurs exécutant LLTry.
+        </li>
+    </ul>
+    <h3>DROITS DE PROPRIÉTÉ INTELLECTUELLE</h3>
+    <p>Vous reconnaissez que tous les droits de propriété intellectuelle de LLTry
+        dans le monde entier nous appartiennent (ou appartiennent à nos titulaires de licences), que les droits sur Lifelight
+        vous sont concédés sous licence (non vendus), et que vous n’avez aucun droit de propriété intellectuelle
+        sur LLTry autres que le droit d’utiliser LLTry en confirmité
+        avec les présentes conditions.</p>
+    <h3>NOTRE RESPONSABILITÉ EN CAS DE PERTE OU DE DOMMAGE SUBI PAR VOUS –
+        LA PRÉSENTE CLAUSE NE S’APPLIQUE QU’AUX PATIENTS.</h3>
+    <p>LLTry est fourni « tel quel » à des fins de démonstration uniquement. Nous ne
+        garantissons pas que l’application est exacte, fiable ou adaptée à un usage médical
+        ou diagnostique.</p>
+    <p><b>Nous sommes responsables envers vous des pertes et dommages prévisibles causés
+        par nous.</b> Dans le cas où nous ne respecterions pas les présentes conditions, nous serions tenus responsables des pertes ou
+        dommages que vous subiriez et qui seraient le résultat prévisible de notre violation desdites conditions
+        ou de notre manquement à faire preuve d’un soin et d’une compétence raisonnables. Nous ne saurions, en revanche, être tenus responsables
+        de toute perte ou tout dommage qui ne serait pas considéré comme prévisible. La perte ou le dommage est
+        prévisible s’il est évident qu’il se produira ou si, au moment de l’établissement
+        de la présente licence, vous et nous savions qu’il pouvait se produire.</p>
+    <p><b>Nous n’excluons ni ne limitons en aucune manière notre responsabilité envers vous
+        lorsqu’il serait illégal de le faire.</b> Cela inclut la responsabilité en cas de décès ou de blessures
+        causés par notre négligence ou celle de nos employés,
+        agents ou sous-traitants, ou en cas de fraude ou de fausse
+        déclaration.</p>
+    <p><b>Lorsque nous sommes responsables des dommages sur vos biens.</b> Si le contenu numérique
+        défectueux que nous avons fourni endommage un appareil ou
+        un contenu numérique vous appartenant, nous réparerons le dommage
+        ou vous verserons une indemnité. Cependant, nous ne serons pas tenus responsables des dommages que vous auriez
+        pu éviter en suivant nos conseils à l’occasion d’une mise à jour proposée gratuitement,
+        ou pour les dommages causés par vous après n’avoir pas suivi correctement
+        les instructions d’installation ou ne pas disposer de la configuration minimale
+        du système que nous recommandons.</p>
+    <h3>EN CAS D’URGENCE MÉDICALE, VOUS DEVEZ TOUJOURS APPELER DIRECTEMENT
+        VOTRE PRESTATAIRE DE SOINS DE SANTÉ OU UTILISER LES
+        LIGNES D’ASSISTANCE DE VOTRE SYSTÈME DE SOINS DE SANTÉ NATIONAL.</h3>
+    <br>
+    <h3>NOUS POUVONS METTRE FIN À VOS DROITS D’UTILISER LIFELIGHT SI VOUS VIOLEZ
+        LES PRÉSENTES CONDITIONS</h3>
+    <p>Si nous considérons qu’une violation des présentes conditions s’est produite, nous pouvons
+        prendre les mesures que nous jugerons appropriées.</p>
+    <p>Si vous avez commis une infraction grave aux présentes conditions, nous pouvons prendre toutes ou partie des
+        mesures suivantes :</p>
+    <ul>
+        <li>le retrait immédiat, temporaire ou permanent de votre droit d’utilisation de
+            LLTry ;
+        </li>
+        <li>la suppression immédiate, temporaire ou permanente de toute donnée
+            chargée par vous sur LLTry ;
+        </li>
+        <li>vous donner un avertissement ;
+        </li>
+        <li>une action en justice contre vous ;
+        </li>
+        <li>la divulgation des informations aux autorités chargées de l’application de la loi
+            dans la mesure où nous la jugeons raisonnablement nécessaire ou requise par la loi.
+        </li>
+    </ul>
+    <p>Les mesures que nous sommes susceptibles de prendre ne sont pas limitées à celles décrites ci-dessus
+        et nous pouvons prendre toute autre mesure que nous jugerons appropriée.</p>
+    <p>Si nous mettons fin à vos droits d’utilisation de LLTry :</p>
+    <ul>
+        <li>vous devez cesser toutes les activités autorisées par les présentes conditions, y compris
+            votre utilisation de LLTry.
+        </li>
+        <li>vous devez supprimer ou retirer l’Application de
+            l’appareil en votre possession, détruire immédiatement toutes les copies
+            de l’Application en votre possession et nous confirmer que vous
+            l’avez fait ;
+        </li>
+    </ul>
+    <h3>TRANSFERT DE LA PRÉSENTE LICENCE À UNE AUTRE PERSONNE</h3>
+    <p>Nous pouvons transférer, céder, facturer, sous-traiter ou traiter de toute autre
+        façon tout ou partie de nos droits et obligations, en vertu des présentes
+        conditions.</p>
+    <p>En revanche, vous ne pouvez pas transférer vos droits ou vos obligations
+        en vertu des présentes conditions à un tiers sans un accord écrit de notre part.</p>
+    <h3>DROITS DES TIERS</h3>
+    <p>Sauf droits spécifiques à l’organisation que vous représentez, les présentes conditions
+        ne donnent lieu à aucun droit au titre du Contracts (Rights of Third Parties) Act 1999
+        por faire respecter ses conditions.</p>
+    <h3>SI L’UNE DES DISPOSITIONS DU PRÉSENT CONTRAT EST JUGÉE ILLÉGALE PAR UN TRIBUNAL,
+        LE RESTE DU CONTRAT DEMEURE EN VIGUEUR</h3>
+    <p>Chacun des paragraphes des présentes conditions est pris en compte séparément. Si un ou une autorité
+        compétente décide que l’un de ceux-ci est illégal, les autres paragraphes demeureront
+        en vigueur.</p>
+    <h3>MÊME SI NOUS RETARDONS L’EXÉCUTION DES PRÉSENTES CONDITIONS, NOUS POUVONS TOUJOURS
+        LES APPLIQUER PLUS TARD</h3>
+    <p>Même si nous tardons à exécuter les présentes conditions, nous pouvons toujours les appliquer
+        plus tard. Si nous n’insistons pas immédiatement pour que vous fassiez ce que vous êtes tenu
+        de faire en vertu des présentes conditions de licence, ou si nous tardons à prendre des mesures
+        à votre encontre après une rupture des présentes conditions de licence, cela ne signifie pas pour autant que vous soyez dispensé
+        de remplir vos obligations, et cela ne nous empêchera pas de prendre des mesures contre vous
+        à une date ultérieure.</p>
+    <h3>QUELLES LOIS S’APPLIQUENT AUX PRÉSENTES CONDITIONS ET QUELLE EST LA JURIDICTION COMPÉTENTE ?</h3>
+    <p>Les présentes conditions, leur objet et leur formation (ainsi que tout litige ou réclamation non-contractuel) sont
+        régis par le droit anglais et soumis à la compétence exclusive des tribunaux d’Angleterre et du Pays de Galles.
+        Si vous n’êtes pas basé en Angleterre et au Pays de Galles, vous pouvez engager des poursuites judiciaires à l’égard de Lifelight dans
+        le pays où vous vous trouvez.</p>
+    <p><strong>En cochant la case, vous acceptez les présentes conditions qui vous lieront au niveau contractuel.</strong></p>
+    <p><strong>Si vous n’acceptez pas les présentes conditions, ne cochez pas la case.</strong></p>
+</main>
+
+</body></html>


### PR DESCRIPTION
Added new French HTML pages for:
- IFU: https://xim-lifelight.github.io/ifu/ll-ifu/ll-singleproduct-ifu-c1-fr.html
- Label: https://xim-lifelight.github.io/ifu/ll-ifu/ll-singleproduct-label-fr.html
- LLTry T&Cs: https://xim-lifelight.github.io/termsandconditions/lltry-terms-and-conditions-fr.html
- SDK T&Cs: https://xim-lifelight.github.io/termsandconditions/lifelightclassII-terms-and-conditions-fr.html

- Updated the existing Privacy Policy page of French: https://xim-lifelight.github.io/privacy-policy/lifelight-privacy-policy-fr.html
- Removed the option of ‘[Catégories spéciales de données](https://lifelight.ai/privacy-notice/#special)’ from Contents (13th option in corresponding English page) of Privacy Policy French Page as on clicking this link, the user is redirected to an English HTML page.
