### PR TITLE
LD2C-151: Update privacy notice to reflect app analytics consent

### DIFF
--- a/privacy-policy/lifelight-connect/lifelight-connect-privacy-policy.html
+++ b/privacy-policy/lifelight-connect/lifelight-connect-privacy-policy.html
@@ -43,7 +43,7 @@
             <li><a href="#transfers">International Transfers</a></li>
             <li><a href="#retention">Data Retention</a></li>
             <li><a href="#security">Security and Technology</a></li>
-            <li><a href="#cookies">Website Analytics and Cookies</a></li>
+            <li><a href="#cookies">Analytics and Cookies</a></li>
             <li><a href="#rights">Your Data Protection Rights</a></li>
             <li><a href="#complaints">Complaints</a></li>
             <li><a href="#us-rights">United States Privacy Rights</a></li>
@@ -311,10 +311,13 @@
     </section>
 
     <section id="cookies">
-        <h3>13. Website Analytics and Cookies</h3>
+        <h3>13. Analytics and Cookies</h3>
         <p>Our websites use cookies and similar technologies to support website functionality, analytics and security monitoring.</p>
         <p>Where required by applicable law, cookie consent mechanisms are used to allow users to manage their preferences.</p>
         <p>Further information about the cookies used on our websites, including their purpose and duration, is provided in our <a href="https://lifelight.ai/cookie-declaration/">Cookie Policy</a>.</p>
+        <h4>App Analytics</h4>
+        <p>The Lifelight Connect app uses Mixpanel, a third-party analytics tool, to help us understand how the app is used and to improve your experience. Unlike website cookies, app analytics are only activated if you choose to allow them when you first open the app. No analytics data is collected before you have given your consent.</p>
+        <p>You can change your analytics preference at any time in the Settings section of the app.</p>
     </section>
 
     <section id="rights">


### PR DESCRIPTION
## Summary

- Renamed section 13 heading from **"Website Analytics and Cookies"** to **"Analytics and Cookies"** in both the table of contents and the section heading
- Added new **App Analytics** subsection after the existing three cookie paragraphs, disclosing Mixpanel usage and that app analytics are consent-gated (not activated before the user gives consent)
- All existing section 13 content is unchanged; the `#cookies` anchor remains intact

## Context

Pre-launch compliance requirement confirmed by DPO. The Lifelight Connect app uses Mixpanel for analytics, but the previous privacy notice only covered website cookies. This update makes the notice accurate and explicit about in-app analytics consent.

## Jira

[LD2C-151](https://lifelight.atlassian.net/browse/LD2C-151)

## Test plan

- [ ] Visit the hosted privacy notice and navigate to section 13 — heading reads "Analytics and Cookies"
- [ ] App Analytics subsection is visible below the three existing cookie paragraphs
- [x] Table of contents entry for section 13 reads "Analytics and Cookies"
- [ ] Clicking the section 13 ToC link still scrolls to the correct section (`#cookies` anchor works)
- [ ] Existing three paragraphs in section 13 are unchanged

[LD2C-151]: https://lifelight.atlassian.net/browse/LD2C-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ