### PR TITLE
LD-5582: add config template

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Render config and deploy Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Render config values into templated pages
+        run: python3 scripts/render_config.py
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,6 +3,8 @@ name: Render config and deploy Pages
 on:
   push:
     branches: [master]
+  pull_request:
+    branches: [master]
   workflow_dispatch:
 
 permissions:

--- a/config.json
+++ b/config.json
@@ -1,0 +1,17 @@
+{
+  "dateOfIssue": "27/05/26",
+  "revision": "10",
+  "mfgDate": "(11)260527",
+  "softwareVersion": "(8012)6.0.1-0",
+  "labelMfgDate": "05 2026",
+  "changeControl": {
+    "en": "refer to e-QMS",
+    "de": "siehe e-QMS",
+    "es": "consultar el e-QMS",
+    "es-LAT": "consultar el e-QMS",
+    "fr": "se référer à l'e-QMS",
+    "it": "fare riferimento all'e-QMS",
+    "nl": "zie e-QMS",
+    "th": "โปรดดู e-QMS"
+  }
+}

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-de.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-de.html
@@ -31,11 +31,11 @@
         <img src="./img/operator and subject.svg" alt="Testperson und Bediener mit Lifelight" width="400px" class="img-reduced"></section>
     <section id="info"><!--top plate info COPY FROM HERE-->
         <div class="column2">
-            <p><strong>Ausgabedatum:</strong> 27/05/26<br>
+            <p><strong>Ausgabedatum:</strong> {{dateOfIssue}}<br>
                 <strong>IFU-Ref.:</strong> REC-QMS-005<br>
-                <strong>Überarbeitung:</strong> 10<br>
-                <strong>Falls überarbeitet, Datum der Überarbeitung:</strong> 27/05/26<br>
-                <strong>Änderungskontrollnummer:</strong> siehe e-QMS<br>
+                <strong>Überarbeitung:</strong> {{revision}}<br>
+                <strong>Falls überarbeitet, Datum der Überarbeitung:</strong> {{dateOfIssue}}<br>
+                <strong>Änderungskontrollnummer:</strong> {{changeControl}}<br>
                 <strong>Eindeutige Gerätekennung:</strong> 05060776720019<br>
                 <strong>Gerätename:</strong> Lifelight<br>
                 <strong>Marke:</strong> Lifelight</p>
@@ -56,9 +56,9 @@
             </div>
             <div class="columnSQ">
                 <p class="small">(01)05060776720019 </p>
-                <p class="small">(11)260527</p>
+                <p class="small">{{mfgDate}}</p>
                 <p class="small">(21)LLF-002</p>
-                <p class="small">(8012)6.0.1-0</p>
+                <p class="small">{{softwareVersion}}</p>
             </div>
         </div>
         <h3>Symbole auf dem Gerät und in der Dokumentation</h3>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-es-LAT.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-es-LAT.html
@@ -30,11 +30,11 @@
         <img src="./img/operator and subject.svg" alt="usuario y operador con Lifelight" width="400px" class="img-reduced"></section>
     <section id="info"><!--top plate info COPY FROM HERE-->
         <div class="column2">
-            <p><strong>Fecha de emisión:</strong> 27/05/26 <br>
+            <p><strong>Fecha de emisión:</strong> {{dateOfIssue}} <br>
                 <strong>Ref. IFU:</strong> REC-QMS-005<br>
-                <strong>Revisión:</strong> 10<br>
-                <strong>Fecha de revisión (si fue revisado):</strong> 27/05/26<br>
-                <strong>Número de control de cambios:</strong> consultar el e-QMS<br>
+                <strong>Revisión:</strong> {{revision}}<br>
+                <strong>Fecha de revisión (si fue revisado):</strong> {{dateOfIssue}}<br>
+                <strong>Número de control de cambios:</strong> {{changeControl}}<br>
                 <strong>Identificador único del dispositivo:</strong> 05060776720019<br>
                 <strong>Nombre del dispositivo:</strong> Lifelight<br>
                 <strong>Marca registrada:</strong> Lifelight</p>
@@ -55,9 +55,9 @@
             </div>
             <div class="columnSQ">
                 <p class="small">(01)05060776720019 </p>
-                <p class="small">(11)260527</p>
+                <p class="small">{{mfgDate}}</p>
                 <p class="small">(21)LLF-002</p>
-                <p class="small">(8012)6.0.1-0</p>
+                <p class="small">{{softwareVersion}}</p>
             </div>
         </div>
         <h3>Símbolos en el dispositivo y documentación</h3>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-es.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-es.html
@@ -31,11 +31,11 @@
     <img src="./img/operator and subject.svg" alt="usuario y operador con Lifelight" width="400px" class="img-reduced"></section>
   <section id="info"><!--top plate info COPY FROM HERE-->
     <div class="column2">
-      <p><strong>Fecha de publicación:</strong> 27/05/26 <br>
+      <p><strong>Fecha de publicación:</strong> {{dateOfIssue}} <br>
         <strong>Ref. de las instrucciones de uso:</strong> REC-QMS-005<br>
-        <strong>Revisión:</strong> 10<br>
-        <strong>Si se revisa, fecha de revisión:</strong> 27/05/26<br>
-        <strong>Número de control de cambios:</strong> consultar el e-QMS<br>
+        <strong>Revisión:</strong> {{revision}}<br>
+        <strong>Si se revisa, fecha de revisión:</strong> {{dateOfIssue}}<br>
+        <strong>Número de control de cambios:</strong> {{changeControl}}<br>
         <strong>Identificador único del dispositivo:</strong> 05060776720019<br>
         <strong>Nombre del dispositivo:</strong> Lifelight<br>
         <strong>Marca comercial:</strong> Lifelight</p>
@@ -56,9 +56,9 @@
       </div>
       <div class="columnSQ">
         <p class="small">(01)05060776720019 </p>
-        <p class="small">(11)260527</p>
+        <p class="small">{{mfgDate}}</p>
         <p class="small">(21)LLF-002</p>
-        <p class="small">(8012)6.0.1-0</p>
+        <p class="small">{{softwareVersion}}</p>
       </div>
     </div>
     <h3>Símbolos en el dispositivo y la documentación</h3>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-fr.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-fr.html
@@ -30,11 +30,11 @@
         <img src="img/operator and subject.svg" alt="sujet et opérateur avec lifelight" width="400px" class="img-reduced"></section>
     <section id="info"><!--top plate info COPY FROM HERE-->
         <div class="column2">
-            <p><strong>Date d’émission :</strong> 27/05/26 <br>
+            <p><strong>Date d’émission :</strong> {{dateOfIssue}} <br>
                 <strong>Réf. des instructions d’utilisation :</strong> REC-QMS-005<br>
-                <strong>Révision :</strong> 10<br>
-                <strong>Si révision, date de la révision :</strong> 27/05/26<br>
-                <strong>Numéro de contrôle des changements :</strong> se référer à l'e-QMS<br>
+                <strong>Révision :</strong> {{revision}}<br>
+                <strong>Si révision, date de la révision :</strong> {{dateOfIssue}}<br>
+                <strong>Numéro de contrôle des changements :</strong> {{changeControl}}<br>
                 <strong>Identifiant unique de l'appareil :</strong> 05060776720019<br>
                 <strong>Nom du l'appareil :</strong> Lifelight<br>
                 <strong>Marque commerciale :</strong> Lifelight</p>
@@ -55,9 +55,9 @@
             </div>
             <div class="columnSQ">
                 <p class="small">(01)05060776720019 </p>
-                <p class="small">(11)260527</p>
+                <p class="small">{{mfgDate}}</p>
                 <p class="small">(21)LLF-002</p>
-                <p class="small">(8012)6.0.1-0</p>
+                <p class="small">{{softwareVersion}}</p>
             </div>
         </div>
         <h3>Symboles sur l'appareil et documentation</h3>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-it.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-it.html
@@ -30,11 +30,11 @@
     <img src="./img/operator and subject.svg" alt="soggetto e operatore con lifelight" width="400px" class="img-reduced"></section>
   <section id="info"><!--top plate info COPY FROM HERE-->
     <div class="column2">
-      <p><strong>Data di emissione:</strong> 27/05/26 <br>
+      <p><strong>Data di emissione:</strong> {{dateOfIssue}} <br>
         <strong>Rif. IFU:</strong> REC-QMS-005<br>
-        <strong>Revisione:</strong> 10<br>
-        <strong>In caso di revisione avvenuta, data di revisione:</strong> 27/05/26<br>
-        <strong>Numero di controllo delle modifiche:</strong> fare riferimento all'e-QMS<br>
+        <strong>Revisione:</strong> {{revision}}<br>
+        <strong>In caso di revisione avvenuta, data di revisione:</strong> {{dateOfIssue}}<br>
+        <strong>Numero di controllo delle modifiche:</strong> {{changeControl}}<br>
         <strong>Identificativo univoco del dispositivo:</strong> 05060776720019<br>
         <strong>Nome del dispositivo:</strong> Lifelight<br>
         <strong>Marchio d'impresa:</strong> Lifelight</p>
@@ -55,9 +55,9 @@
       </div>
       <div class="columnSQ">
         <p class="small">(01)05060776720019 </p>
-        <p class="small">(11)260527</p>
+        <p class="small">{{mfgDate}}</p>
         <p class="small">(21)LLF-002</p>
-        <p class="small">(8012)6.0.1-0</p>
+        <p class="small">{{softwareVersion}}</p>
       </div>
     </div>
     <h3>Simboli sul dispositivo e documentazione</h3>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-nl.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-nl.html
@@ -31,11 +31,11 @@
     <img src="./img/operator and subject.svg" alt="persoon en gebruiker met Lifelight" width="400px" class="img-reduced"></section>
   <section id="info"><!--top plate info COPY FROM HERE-->
     <div class="column2">
-      <p><strong>Datum van uitgifte:</strong> 27/05/26 <br>
+      <p><strong>Datum van uitgifte:</strong> {{dateOfIssue}} <br>
         <strong>IFU-referentie:</strong> REC-QMS-005 <br>
-        <strong>Revisie:</strong> 10<br>
-        <strong>Indien herzien, datum van revisie:</strong> 27/05/26<br>
-        <strong>Wijzigingscontrolenummer:</strong> zie e-QMS<br>
+        <strong>Revisie:</strong> {{revision}}<br>
+        <strong>Indien herzien, datum van revisie:</strong> {{dateOfIssue}}<br>
+        <strong>Wijzigingscontrolenummer:</strong> {{changeControl}}<br>
         <strong>Unieke hulpmiddelenidentificatie (UDI):</strong> 05060776720019<br>
         <strong>Naam van het hulpmiddel:</strong> Lifelight<br>
         <strong>Handelsmerk:</strong> Lifelight</p>
@@ -56,9 +56,9 @@
       </div>
       <div class="columnSQ">
         <p class="small">(01)05060776720019 </p>
-        <p class="small">(11)260527</p>
+        <p class="small">{{mfgDate}}</p>
         <p class="small">(21)LLF-002</p>
-        <p class="small">(8012)6.0.1-0</p>
+        <p class="small">{{softwareVersion}}</p>
       </div>
     </div>
     <h3>Symbolen op het apparaat en documentatie</h3>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1-th.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1-th.html
@@ -31,11 +31,11 @@
     <img src="./img/operator and subject.svg" alt="ผู้รับการวัดและผู้ปฏิบัติงานด้วย Lifelight" width="400px" class="img-reduced"></section>
   <section id="info"><!--top plate info COPY FROM HERE-->
     <div class="column2">
-      <p><strong>วันที่ออก:</strong> 27/05/26 <br>
+      <p><strong>วันที่ออก:</strong> {{dateOfIssue}} <br>
         <strong>เลขอ้างอิง IFU:</strong> REC-QMS-005<br>
-        <strong>การแก้ไข:</strong> 10<br>
-        <strong>หากมีการแก้ไข วันที่แก้ไข:</strong> 27/05/26<br>
-        <strong>หมายเลขควบคุมการเปลี่ยนแปลง:</strong> โปรดดู e-QMS<br>
+        <strong>การแก้ไข:</strong> {{revision}}<br>
+        <strong>หากมีการแก้ไข วันที่แก้ไข:</strong> {{dateOfIssue}}<br>
+        <strong>หมายเลขควบคุมการเปลี่ยนแปลง:</strong> {{changeControl}}<br>
         <strong>รหัสประจำอุปกรณ์:</strong> 05060776720019<br>
         <strong>ชื่ออุปกรณ์:</strong> Lifelight<br>
         <strong>เครื่องหมายการค้า:</strong> Lifelight</p>
@@ -56,9 +56,9 @@
       </div>
       <div class="columnSQ">
         <p class="small">(01)05060776720019 </p>
-        <p class="small">(11)260527</p>
+        <p class="small">{{mfgDate}}</p>
         <p class="small">(21)LLF-002</p>
-        <p class="small">(8012)6.0.1-0</p>
+        <p class="small">{{softwareVersion}}</p>
       </div>
     </div>
     <h3>สัญลักษณ์บนอุปกรณ์และเอกสาร</h3>

--- a/ifu/ll-ifu/ll-singleproduct-ifu-c1.html
+++ b/ifu/ll-ifu/ll-singleproduct-ifu-c1.html
@@ -31,11 +31,11 @@
          width="400px" class="img-reduced"/></section>
   <section id="info"><!--top plate info COPY FROM HERE-->
       <div class="column2">
-        <p><strong>Date of Issue:</strong> 27/05/26 <br>
+        <p><strong>Date of Issue:</strong> {{dateOfIssue}} <br>
           <strong>IFU Ref:</strong> REC-QMS-005<br>
-          <strong>Revision:</strong> 10<br>
-          <strong>If revised date of revision:</strong> 27/05/26<br>
-          <strong>Change Control Number:</strong> refer to e-QMS<br>
+          <strong>Revision:</strong> {{revision}}<br>
+          <strong>If revised date of revision:</strong> {{dateOfIssue}}<br>
+          <strong>Change Control Number:</strong> {{changeControl}}<br>
           <strong>Unique Device Identifier:</strong> 05060776720019<br>
           <strong>Name of device:</strong> Lifelight<br>
           <strong>Trademark:</strong> Lifelight</p>
@@ -56,9 +56,9 @@
       </div>
       <div class="columnSQ">
         <p class="small">(01)05060776720019&nbsp;</p>
-        <p class="small">(11)260527</p>
+        <p class="small">{{mfgDate}}</p>
         <p class="small">(21)LLF-002</p>
-        <p class="small">(8012)6.0.1-0</p>
+        <p class="small">{{softwareVersion}}</p>
       </div>
     </div>
     <h3>Symbols on the device and documentation</h3>

--- a/ifu/ll-ifu/ll-singleproduct-label-de.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-de.html
@@ -26,7 +26,7 @@
   <section id="logo"><!--top plate info -->
     <div class="column-holder">
       <div class="column2"> <img src="./img/date.svg" width="40px" alt="">
-        <p><strong>05 2026</strong></p>
+        <p><strong>{{labelMfgDate}}</strong></p>
         <img src="./img/factory.svg" alt="Werk" width="40px">
         <p><strong>XIM Ltd.<br>
           University of Southampton Science Park<br>
@@ -78,9 +78,9 @@
         <p><strong>0123</strong></p>
         <p><img src="./img/ll-qr.svg" alt="ll-qr" width="150px"></p>
         <p class="small">(01)05060776720019<br>
-          (11)260527<br>
+          {{mfgDate}}<br>
           (21)LLF-002<br>
-          (8012)6.0.1-0</p>
+          {{softwareVersion}}</p>
         <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
         <p><strong>Eindeutige Gerätekennung:</strong><br>
           05060776720019</p>

--- a/ifu/ll-ifu/ll-singleproduct-label-es-LAT.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-es-LAT.html
@@ -23,7 +23,7 @@
     <section id="logo"><!--top plate info -->
         <div class="column-holder">
             <div class="column2"> <img src="./img/date.svg" width="40px" alt="">
-                <p><strong>11 2025</strong></p>
+                <p><strong>{{labelMfgDate}}</strong></p>
                 <img src="./img/factory.svg" alt="fábrica" width="40px">
                 <p><strong>XIM Ltd.<br> University of Southampton Science Park<br> 2 Venture Road<br> Southampton<br> Hampshire<br> Reino Unido<br> SO16 7NP</strong></p>
                 <img src="./img/ecrep.svg" alt="fábrica" width="90px">
@@ -51,9 +51,9 @@
                 <p><strong>0123</strong></p>
                 <p><img src="./img/ll-qr.svg" alt="ll-qr" width="150px"></p>
                 <p class="small">(01)05060776720019<br>
-                    (11)251117<br>
+                    {{mfgDate}}<br>
                     (21)LLF-002<br>
-                    (8012)6.0.0-1</p>
+                    {{softwareVersion}}</p>
                 <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
                 <p><strong>Identificador único del dispositivo:</strong><br>
                     05060776720019</p>

--- a/ifu/ll-ifu/ll-singleproduct-label-es.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-es.html
@@ -25,7 +25,7 @@
   <section id="logo"><!--top plate info -->
     <div class="column-holder">
       <div class="column2"> <img src="./img/date.svg" width="40px" alt="">
-        <p><strong>05 2026</strong></p>
+        <p><strong>{{labelMfgDate}}</strong></p>
         <img src="./img/factory.svg" alt="fábrica" width="40px">
         <p><strong>XIM Ltd.<br>
           University of Southampton Science Park<br>
@@ -77,9 +77,9 @@
         <p><strong>0123</strong></p>
         <p><img src="./img/ll-qr.svg" alt="ll-qr" width="150px"></p>
         <p class="small">(01)05060776720019<br>
-          (11)260527<br>
+          {{mfgDate}}<br>
           (21)LLF-002<br>
-          (8012)6.0.1-0</p>
+          {{softwareVersion}}</p>
         <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
         <p><strong>Identificador individual del dispositivo:</strong><br>
           05060776720019</p>

--- a/ifu/ll-ifu/ll-singleproduct-label-fr.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-fr.html
@@ -22,7 +22,7 @@
     <section id="logo"><!--top plate info -->
         <div class="column-holder">
             <div class="column2"> <img src="img/date.svg" width="40px" alt="">
-                <p><strong>05 2026</strong></p>
+                <p><strong>{{labelMfgDate}}</strong></p>
                 <img src="img/factory.svg" alt="usine" width="40px">
                 <p><strong>XIM Ltd.<br>
                     University of Southampton Science Park<br>
@@ -75,9 +75,9 @@
                 <p><strong>0123</strong></p>
                 <p><img src="img/ll-qr.svg" alt="ll-qr" width="150px"></p>
                 <p class="small">(01)05060776720019<br>
-                    (11)260527<br>
+                    {{mfgDate}}<br>
                     (21)LLF-002<br>
-                    (8012)6.0.1-0</p>
+                    {{softwareVersion}}</p>
                 <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
                 <p><strong>Identifiant unique de l’appareil :</strong><br>
                     05060776720019</p>

--- a/ifu/ll-ifu/ll-singleproduct-label-it.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-it.html
@@ -23,7 +23,7 @@
   <section id="logo"><!--top plate info -->
     <div class="column-holder">
       <div class="column2"> <img src="./img/date.svg" width="40px" alt="">
-        <p><strong>05 2026</strong></p>
+        <p><strong>{{labelMfgDate}}</strong></p>
         <img src="./img/factory.svg" alt="manifattura" width="40px">
         <p><strong>XIM Ltd.<br>
           University of Southampton Science Park<br>
@@ -75,9 +75,9 @@
         <p><strong>0123</strong></p>
         <p><img src="./img/ll-qr.svg" alt="ll-qr" width="150px"></p>
         <p class="small">(01)05060776720019<br>
-          (11)260527<br>
+          {{mfgDate}}<br>
           (21)LLF-002<br>
-          (8012)6.0.1-0</p>
+          {{softwareVersion}}</p>
         <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
         <p><strong>Identificatore univoco del dispositivo:</strong><br>
           05060776720019</p>

--- a/ifu/ll-ifu/ll-singleproduct-label-nl.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-nl.html
@@ -25,7 +25,7 @@
   <section id="logo"><!--top plate info -->
     <div class="column-holder">
       <div class="column2"> <img src="./img/date.svg" width="40px" alt="">
-        <p><strong>05 2026</strong></p>
+        <p><strong>{{labelMfgDate}}</strong></p>
         <img src="./img/factory.svg" alt="fabriek" width="40px">
         <p><strong>XIM Ltd.<br>
           University of Southampton Science Park<br>
@@ -77,9 +77,9 @@
         <p><strong>0123</strong></p>
         <p><img src="./img/ll-qr.svg" alt="ll-qr" width="150px"></p>
         <p class="small">(01)05060776720019<br>
-          (11)260527<br>
+          {{mfgDate}}<br>
           (21)LLF-002<br>
-          (8012)6.0.1-0</p>
+          {{softwareVersion}}</p>
         <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
         <p><strong>Unieke apparaatidentificatie:</strong><br>
           05060776720019</p>

--- a/ifu/ll-ifu/ll-singleproduct-label-th.html
+++ b/ifu/ll-ifu/ll-singleproduct-label-th.html
@@ -25,7 +25,7 @@
   <section id="logo"><!--top plate info -->
     <div class="column-holder">
       <div class="column2"> <img src="./img/date.svg" width="40px" alt="">
-        <p><strong>05 2026</strong></p>
+        <p><strong>{{labelMfgDate}}</strong></p>
         <img src="./img/factory.svg" alt="โรงงาน" width="40px">
         <p><strong>XIM Ltd.<br>
           University of Southampton Science Park<br>
@@ -78,9 +78,9 @@
         <p><strong>0123</strong></p>
         <p><img src="./img/ll-qr.svg" alt="ll-qr" width="150px"></p>
         <p class="small">(01)05060776720019<br>
-          (11)260527<br>
+          {{mfgDate}}<br>
           (21)LLF-002<br>
-          (8012)6.0.1-0</p>
+          {{softwareVersion}}</p>
         <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
         <p><strong>รหัสประจำอุปกรณ์:</strong><br>
           05060776720019</p>

--- a/ifu/ll-ifu/ll-singleproduct-label.html
+++ b/ifu/ll-ifu/ll-singleproduct-label.html
@@ -24,7 +24,7 @@
   <section id="logo"><!--top plate info -->
     <div class="column-holder">
       <div class="column2"> <img src="img/date.svg" width="40px" alt=""/>
-        <p><strong>05 2026</strong></p>
+        <p><strong>{{labelMfgDate}}</strong></p>
         <img src="img/factory.svg" alt="factory" width="40px"/>
         <p><strong>XIM Ltd.<br>
           University of Southampton Science Park<br>
@@ -76,9 +76,9 @@
         <p><strong>0123</strong></p>
         <p><img src="img/ll-qr.svg" alt="ll-qr" width="150px"/></p>
         <p class="small">(01)05060776720019<br>
-          (11)260527<br>
+          {{mfgDate}}<br>
           (21)LLF-002<br>
-          (8012)6.0.1-0</p>
+          {{softwareVersion}}</p>
         <p class="small"><img src="img/serial.svg" alt="SN" height="25px" style="vertical-align: middle;"/> LLF-002</p>
         <p><strong>Unique Device Identifier:</strong><br>
           05060776720019</p>

--- a/scripts/render_config.py
+++ b/scripts/render_config.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Render {{token}} placeholders in IFU/label pages using config.json."""
+import argparse
+import json
+import sys
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONFIG_PATH = REPO_ROOT / "config.json"
+SOURCE_DIR = REPO_ROOT / "ifu" / "ll-ifu"
+
+TOKEN_PATTERN = re.compile(r"\{\{(\w+)\}\}")
+LANG_SUFFIXES = ["es-LAT", "de", "es", "fr", "it", "nl", "th"]
+
+
+def detect_lang(stem):
+    for suffix in LANG_SUFFIXES:
+        if stem.endswith(f"-{suffix}"):
+            return suffix
+    return "en"
+
+
+def resolve_token(config, token, lang, filename):
+    if token == "changeControl":
+        return config["changeControl"][lang]
+    if token not in config:
+        raise KeyError(f"Unresolved token {{{{{token}}}}} in {filename}")
+    return config[token]
+
+
+def render_content(content, config, lang, filename):
+    def replace(match):
+        return resolve_token(config, match.group(1), lang, filename)
+    return TOKEN_PATTERN.sub(replace, content)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Render config.json values into tokenized IFU/label pages.")
+    parser.add_argument("--check", action="store_true", help="Verify all tokens resolve without writing any files.")
+    args = parser.parse_args()
+
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    errors = []
+
+    for path in sorted(SOURCE_DIR.glob("*.html")):
+        content = path.read_text(encoding="utf-8")
+        if not content.strip():
+            continue  # skip empty files (e.g. us-en)
+        lang = detect_lang(path.stem)
+        try:
+            rendered = render_content(content, config, lang, path.name)
+        except KeyError as e:
+            errors.append(str(e))
+            continue
+        if not args.check:
+            path.write_text(rendered, encoding="utf-8")
+        print(f"{'Checked' if args.check else 'Rendered'} {path.name} ({lang})")
+
+    if errors:
+        for e in errors:
+            print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Jira Ticket
https://lifelight.atlassian.net/browse/LD-5582

---

## What
Removes the manual, error-prone process of hand-editing release values (date of issue, revision, manufacturing date, software version, change control text) across all 16 IFU/label HTML files on every release. These values were hardcoded up until now.

---

## How
- Added config.json as the single-source-of-truth for release values: dateOfIssue, revision, mfgDate, softwareVersion, labelMfgDate, and changeControl (keyed per language).
- Replaced the hardcoded values in all 16 IFU/label HTML files with {{token}} placeholders (e.g. {{dateOfIssue}}, {{revision}}, {{mfgDate}}, {{softwareVersion}}). No translated copy, structure, or styling touched.
- Added `scripts/render_config.py`, which reads config.json, detects each file's language from its filename suffix, and substitutes tokens — raising an error if any token can't be resolved.
- Added `.github/workflows/pages.yml`: on push to master, runs the render step and deploys via GitHub Pages. Deploy only ever runs on push events, never on manual dispatch.

